### PR TITLE
ci: Unify fledge.yaml across cynkratemplate and fledge

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -98,8 +98,9 @@ jobs:
 
       - uses: ./.github/workflows/install
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           pak-version: devel
-          packages: cynkra/fledge
+          packages: ${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}
           cache-version: fledge-1
 
       - name: Count rulesets

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -99,7 +99,6 @@ jobs:
       - uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pak-version: devel
           packages: ${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}
           cache-version: fledge-1
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Passed on to r-lib/actions/setup-r-dependencies@v2
     required: false
     default: 1
+  pak-version:
+    description: Passed on to r-lib/actions/setup-r-dependencies@v2
+    required: false
+    default: stable
 
 runs:
   using: "composite"
@@ -114,7 +118,7 @@ runs:
       env:
         GITHUB_PAT: ${{ inputs.token }}
       with:
-        pak-version: stable
+        pak-version: ${{ inputs.pak-version }}
         needs: ${{ inputs.needs }}
         packages: ${{ inputs.packages }}
         extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: Passed on to r-lib/actions/setup-r-dependencies@v2
     required: false
     default: 1
-  pak-version:
-    description: Passed on to r-lib/actions/setup-r-dependencies@v2
-    required: false
-    default: stable
 
 runs:
   using: "composite"
@@ -118,7 +114,7 @@ runs:
       env:
         GITHUB_PAT: ${{ inputs.token }}
       with:
-        pak-version: ${{ inputs.pak-version }}
+        pak-version: stable
         needs: ${{ inputs.needs }}
         packages: ${{ inputs.packages }}
         extra-packages: ${{ inputs.extra-packages }} ${{ ( matrix.covr && 'r-lib/covr xml2' ) || '' }} ${{ steps.get-extra.outputs.packages }}


### PR DESCRIPTION
Pick `local::.` when running in cynkra/fledge (dogfood), otherwise
install from GitHub. Use dev pak via a new `pak-version` input on the
install composite action.