### PR TITLE
ci: Centralize R-CMD-check / install / roxygenize improvements from consumers

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: rcc-smoke-2
-          needs: build, check, website
+          needs: build, check, website, roxygen2
           # Beware of using dev pkgdown here, has brought in dev dependencies in the past
           extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/pkgdown deps::.
 
@@ -312,6 +312,10 @@ jobs:
 
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
+        with:
+          # Generic: forward any per-entry environment variables defined in the
+          # test matrix (see .github/versions-matrix.R) to the custom action.
+          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:
@@ -336,7 +340,11 @@ jobs:
         shell: Rscript {0}
 
       - uses: ./.github/workflows/update-snapshots
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        # Generic escape hatch: a custom action may set SKIP_UPDATE_SNAPSHOTS
+        # to opt out of running the snapshot updater,
+        # which runs tests directly via testthat::test_local()
+        # and is difficult to disable otherwise.
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && env.SKIP_UPDATE_SNAPSHOTS != 'true'
         with:
           base: ${{ github.head_ref }}
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -147,13 +147,30 @@ runs:
     - name: Use ccache for compiling R code, and parallelize
       run: |
         mkdir -p ~/.R
-        echo 'CC      :=  ccache $(CC)' >> ~/.R/Makevars
-        echo 'CXX     :=  ccache $(CXX)' >> ~/.R/Makevars
-        echo 'CXX11   :=  ccache $(CXX11)' >> ~/.R/Makevars
-        echo 'CXX14   :=  ccache $(CXX14)' >> ~/.R/Makevars
-        echo 'CXX17   :=  ccache $(CXX17)' >> ~/.R/Makevars
+        # Infer each compiler default for the active R version from R CMD config,
+        # then prepend ccache. Reading the resolved defaults preserves the
+        # standard flags R selects per version (e.g. -std=gnu2x for C, -std=gnu++17
+        # / -std=gnu++20 for C++); a plain "CC = ccache gcc" override would drop
+        # them and silently downgrade the standard across the version matrix.
+        # Inference uses an empty user Makevars so we always read the pristine
+        # Makeconf defaults, never a value we just wrote.
+        # Note: the versioned switches (CXX11..CXX23) intentionally come out as
+        # bare "g++" with no -std flag. R keeps the standard in a separate
+        # CXXnnSTD variable (CXX17STD = -std=gnu++17, ...) and applies it on top
+        # at compile time, so wrapping only CXXnn with ccache is correct and we
+        # must NOT pin -std here ourselves.
+        empty_makevars="$(mktemp)"
+        for var in CC CXX CXX11 CXX14 CXX17 CXX20 CXX23; do
+          val="$(R_MAKEVARS_USER="$empty_makevars" R CMD config "$var" 2>/dev/null || true)"
+          if [ -n "$val" ]; then
+            echo "$var = ccache $val" >> ~/.R/Makevars
+          fi
+        done
+        rm -f "$empty_makevars"
         echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
+        echo "===== generated ~/.R/Makevars ====="
         cat ~/.R/Makevars
+        echo "==================================="
 
         echo 'CCACHE_SLOPPINESS=locale,time_macros' | tee -a $GITHUB_ENV
 

--- a/.github/workflows/roxygenize/action.yml
+++ b/.github/workflows/roxygenize/action.yml
@@ -5,5 +5,5 @@ runs:
   steps:
     - name: Roxygenize
       run: |
-        try(roxygen2::roxygenize())
+        roxygen2::roxygenize()
       shell: Rscript {0}


### PR DESCRIPTION
## Why

Several consumer repos had improved their GitHub Actions workflows locally, causing them to diverge from this template. This promotes the **generic** improvements back into the template so they spread to all repos, instead of living as drift in individual repos.

## What changes

**`install/action.yml`** — _from r-dbi/RSQLite_
Infer each compiler default for the active R version via `R CMD config` (reading pristine `Makeconf` defaults through an empty user `Makevars`), then prepend `ccache`. The previous `CC := ccache $(CC)` style dropped the per-version `-std` flags R selects (e.g. `-std=gnu2x`, `-std=gnu++17/20`), silently downgrading the C/C++ standard across the version matrix. Versioned switches (`CXX11..CXX23`) are intentionally left as bare `g++`; R applies the standard separately via `CXXnnSTD`.

**`R-CMD-check.yaml`** (matrix job) — _from duckdb/duckdb-r_
- Forward per-entry `matrix.env` into the `custom/before-install` action, so the test matrix (`.github/versions-matrix.R`) can pass environment variables to custom setup.
- Add a `SKIP_UPDATE_SNAPSHOTS` escape hatch on the `update-snapshots` step, so a custom action can opt out of the snapshot updater (which runs `testthat::test_local()` directly and is otherwise hard to disable).

**`R-CMD-check.yaml`** (smoke install) + **`roxygenize/action.yml`** — _from igraph/rigraph_
- Add `roxygen2` to the smoke job's install `needs`.
- Drop the `try()` around `roxygen2::roxygenize()` so roxygenize failures are fatal rather than swallowed.

## Spread / behavioral notes for reviewers

These now apply to **every** repo that syncs from the template:

- **roxygenize is now fatal** — repos that previously relied on `try()` swallowing roxygenize errors will start failing on roxygenize problems. This is intended (surfaces stale docs) but worth flagging.
- `SKIP_UPDATE_SNAPSHOTS` and `matrix.env` forwarding are inert unless a repo's custom action opts into them — safe by default.
- `needs: ... roxygen2` just ensures roxygen2 is installed in the smoke job.

All three files were verified to match their source repos exactly (modulo the intended combination of duckdb-r + rigraph edits in `R-CMD-check.yaml`), and all YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjzn9A39XEA9yijABAFtz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDjzn9A39XEA9yijABAFtz)_