### PR TITLE
ci: Move GHA runners to Ubuntu 26.04 and add ragged Linux arm64 matrix

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -14,7 +14,7 @@ name: rcc dev
 
 jobs:
   matrix:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/workflows/dep-matrix
 
   check-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: matrix
 
     name: Check deps
@@ -51,7 +51,7 @@ jobs:
           echo $matrix | json2yaml
 
   R-CMD-check-base:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     name: base
 
@@ -97,7 +97,7 @@ jobs:
       - matrix
       - R-CMD-check-base
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     name: 'rcc-dev: ${{ matrix.package }}'
 
@@ -125,7 +125,10 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          remotes::install_runiverse("${{ matrix.package }}", linux_distro = "noble")
+          # r-universe builds Linux binaries for ubuntu:latest, which now tracks
+          # 26.04 "resolute" (it no longer publishes "noble"). This matches the
+          # ubuntu-26.04 runner above.
+          remotes::install_runiverse("${{ matrix.package }}", linux_distro = "resolute")
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/R-CMD-check-status.yaml
+++ b/.github/workflows/R-CMD-check-status.yaml
@@ -12,7 +12,7 @@ name: rcc-status
 
 jobs:
   rcc-status:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     name: "Update commit status"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,10 +55,10 @@ jobs:
     # Deliberately amd64. The smoke test is the gate that also styles,
     # roxygenizes, updates snapshots, commits back and deploys pkgdown, so it
     # must run on the most stable and available runner. The ubuntu-26.04-arm
-    # image is still in public preview (possible instability and queueing), so
-    # arm64 is exercised in the full version matrix (rcc-full) instead, where
-    # fail-fast: false isolates failures and jobs don't mutate the repo. Revisit
-    # once the arm image is generally available.
+    # image is still in public preview (actions/runner-images#14226 -- possible
+    # instability and queueing), so arm64 is exercised in the full version matrix
+    # (rcc-full) instead, where fail-fast: false isolates failures and jobs don't
+    # mutate the repo. Revisit once the arm image is generally available.
     runs-on: ubuntu-26.04
 
     outputs:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,14 @@ name: rcc
 
 jobs:
   rcc-smoke:
-    runs-on: ubuntu-24.04
+    # Deliberately amd64. The smoke test is the gate that also styles,
+    # roxygenizes, updates snapshots, commits back and deploys pkgdown, so it
+    # must run on the most stable and available runner. The ubuntu-26.04-arm
+    # image is still in public preview (possible instability and queueing), so
+    # arm64 is exercised in the full version matrix (rcc-full) instead, where
+    # fail-fast: false isolates failures and jobs don't mutate the repo. Revisit
+    # once the arm image is generally available.
+    runs-on: ubuntu-26.04
 
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
@@ -268,7 +275,7 @@ jobs:
         shell: bash
 
   rcc-smoke-check-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     name: "Check matrix"
 
@@ -364,7 +371,7 @@ jobs:
     needs:
       - rcc-smoke
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests)) }}
 

--- a/.github/workflows/commit-suggest.yaml
+++ b/.github/workflows/commit-suggest.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   commit-suggest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.event.workflow_run.event == 'pull_request'
 
     steps:

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   check_news:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -74,7 +74,7 @@ jobs:
         shell: bash
 
   fledge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: check_news
     if: needs.check_news.outputs.should_run == 'true'
     permissions:

--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -21,7 +21,7 @@ name: format-suggest.yaml
 jobs:
   format-suggest:
     name: format-suggest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # Only run this job if changes come from a fork.
     # We commit changes directly on the main repository.
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -110,6 +110,24 @@ runs:
         echo packages=$packages >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Let sudo keep R library env vars (ubuntu-26.04 forbids `sudo -E`)
+      # r-lib/actions/setup-r-dependencies installs pak with
+      #   sudo -E --preserve-env=PATH env R -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), ...)'
+      # From the ubuntu-26.04 runner image on, the sudoers policy rejects `-E`
+      # ("sudo: preserving the entire environment is not supported, '-E' is
+      # ignored"), so R_LIB_FOR_PAK is stripped and dir.create() aborts with a
+      # zero-length 'path' argument. Whitelisting the R_* vars via env_keep
+      # preserves them across sudo's env_reset even though blanket `-E` is
+      # denied, without granting the setenv privilege.
+      # Transient workaround; drop once r-lib/actions handles this upstream.
+      if: runner.os == 'Linux'
+      run: |
+        sudo tee /etc/sudoers.d/r-lib-pak >/dev/null <<'EOF'
+        Defaults env_keep += "R_LIB_FOR_PAK R_LIBS R_LIBS_USER R_LIBS_SITE MAKEFLAGS"
+        EOF
+        sudo chmod 0440 /etc/sudoers.d/r-lib-pak
+      shell: bash
+
     - uses: r-lib/actions/setup-r-dependencies@v2
       env:
         GITHUB_PAT: ${{ inputs.token }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -119,7 +119,9 @@ runs:
       # zero-length 'path' argument. Whitelisting the R_* vars via env_keep
       # preserves them across sudo's env_reset even though blanket `-E` is
       # denied, without granting the setenv privilege.
-      # Transient workaround; drop once r-lib/actions handles this upstream.
+      # Root cause is the ubuntu-26.04 image, still in public preview
+      # (actions/runner-images#14226). No upstream r-lib/actions issue tracks the
+      # `sudo -E` breakage yet -- one should be filed; drop this once fixed.
       if: runner.os == 'Linux'
       run: |
         sudo tee /etc/sudoers.d/r-lib-pak >/dev/null <<'EOF'

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: krlmlr/lock-threads@patch-1
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     name: "pkgdown"
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -79,7 +79,7 @@ jobs:
   merge:
     if: startsWith(github.event.comment.body, '/merge')
     name: merge
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Create and merge pull request
         run: |
@@ -94,6 +94,6 @@ jobs:
           # curl -s -X PUT --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $PR_URL/merge
   # A mock job just to ensure we have a successful build status
   finish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - run: true

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -111,9 +111,11 @@ jobs:
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        # The runner is ubuntu-26.04, but the r-hub system-requirements API only
-        # maps distros up to ubuntu-24.04. The apt package names are stable across
-        # LTS releases, so 24.04 mappings install correctly on 26.04.
+        # The runner is ubuntu-26.04, but remotes::system_requirements() hardcodes
+        # its supported list up to ubuntu-24.04 (r-lib/remotes, R/system_requirements.R;
+        # no tracking issue yet -- one should be filed). The rstudio/r-system-requirements
+        # catalog itself already covers 26.04, and apt package names are stable across
+        # LTS releases, so the 24.04 mappings install correctly on 26.04.
         run: |
           sudo apt-get update -y
           Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "24.04")); package <- "${{ matrix.package }}"; deps <- tools::package_dependencies(package, which = "Suggests")[[1]]; lapply(c(package, deps), function(x) { writeLines(remotes::system_requirements("ubuntu", "24.04", package = x)) })' | sort | uniq > .github/deps.sh

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -8,7 +8,7 @@ name: revdep
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
@@ -16,7 +16,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.posit.co/cran/__linux__/resolute/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
@@ -48,7 +48,7 @@ jobs:
         shell: Rscript {0}
 
   check-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     needs: matrix
     steps:
       - name: Install json2yaml
@@ -65,7 +65,7 @@ jobs:
   R-CMD-check:
     needs: matrix
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
 
     name: 'revdep: ${{ matrix.package }}'
 
@@ -78,7 +78,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.posit.co/cran/__linux__/resolute/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
@@ -99,7 +99,7 @@ jobs:
       - name: Use RSPM
         run: |
           mkdir -p /home/runner/work/_temp/Library
-          echo 'local({release <- system2("lsb_release", "-sc", stdout = TRUE); options(repos=c(CRAN = paste0("https://packagemanager.rstudio.com/all/__linux__/", release, "/latest")), HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))}); .libPaths("/home/runner/work/_temp/Library")' | sudo tee /etc/R/Rprofile.site
+          echo 'local({release <- system2("lsb_release", "-sc", stdout = TRUE); options(repos=c(CRAN = paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest")), HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))}); .libPaths("/home/runner/work/_temp/Library")' | sudo tee /etc/R/Rprofile.site
 
       - name: Install remotes
         run: |
@@ -111,9 +111,12 @@ jobs:
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
+        # The runner is ubuntu-26.04, but the r-hub system-requirements API only
+        # maps distros up to ubuntu-24.04. The apt package names are stable across
+        # LTS releases, so 24.04 mappings install correctly on 26.04.
         run: |
           sudo apt-get update -y
-          Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "22.04")); package <- "${{ matrix.package }}"; deps <- tools::package_dependencies(package, which = "Suggests")[[1]]; lapply(c(package, deps), function(x) { writeLines(remotes::system_requirements("ubuntu", "22.04", package = x)) })' | sort | uniq > .github/deps.sh
+          Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "24.04")); package <- "${{ matrix.package }}"; deps <- tools::package_dependencies(package, which = "Suggests")[[1]]; lapply(c(package, deps), function(x) { writeLines(remotes::system_requirements("ubuntu", "24.04", package = x)) })' | sort | uniq > .github/deps.sh
           cat .github/deps.sh
           sudo sh < .github/deps.sh
 

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -22,11 +22,26 @@ r_versions <- c("devel", as.character(r_release))
 
 macos <- data.frame(os = "macos-latest", r = r_versions[2:3])
 windows <- data.frame(os = "windows-latest", r = r_versions[1:3])
-linux_devel <- data.frame(os = "ubuntu-24.04", r = r_versions[1], `http-user-agent` = "release", check.names = FALSE)
-linux <- data.frame(os = "ubuntu-24.04", r = r_versions[-1])
-covr <- data.frame(os = "ubuntu-24.04", r = r_versions[2], covr = "true", desc = "with covr")
 
-include_list <- list(macos, windows, linux_devel, linux, covr)
+# Linux amd64 (ubuntu-26.04) carries the full historical sweep: R-devel plus
+# every supported release down to the oldest. amd64 has the most mature
+# toolchain and the broadest CRAN binary coverage on Posit Package Manager, so
+# it is where the deep back-compatibility testing lives.
+linux_devel <- data.frame(os = "ubuntu-26.04", r = r_versions[1], `http-user-agent` = "release", check.names = FALSE)
+linux <- data.frame(os = "ubuntu-26.04", r = r_versions[-1])
+covr <- data.frame(os = "ubuntu-26.04", r = r_versions[2], covr = "true", desc = "with covr")
+
+# Linux arm64 (ubuntu-26.04-arm) is intentionally ragged: only the two newest R
+# versions, R-devel and R-release. These are the versions actually deployed to
+# arm64 today (Apple Silicon, AWS Graviton, ...) and the ones with dependable
+# arm64 R builds; re-running the full historical range on a second architecture
+# would add cost without adding meaningful coverage. R-release (and R-devel)
+# overlap with amd64, so at least one R version is exercised on both arches.
+# Note: on aarch64 Linux, setup-r does not use Posit Package Manager, so package
+# dependencies are built from source here.
+linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
+
+include_list <- list(macos, windows, linux_devel, linux, covr, linux_arm64)
 
 if (file.exists(".github/versions-matrix.R")) {
   custom <- source(".github/versions-matrix.R")$value

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -37,8 +37,11 @@ covr <- data.frame(os = "ubuntu-26.04", r = r_versions[2], covr = "true", desc =
 # arm64 R builds; re-running the full historical range on a second architecture
 # would add cost without adding meaningful coverage. R-release (and R-devel)
 # overlap with amd64, so at least one R version is exercised on both arches.
-# Note: on aarch64 Linux, setup-r does not use Posit Package Manager, so package
-# dependencies are built from source here.
+# PPM note: r-lib/actions/setup-r historically disabled Posit Package Manager on
+# aarch64 Linux (r-lib/actions NEWS v2.11.2, 2025-02-19) because PPM shipped no
+# arm64 binaries and would have served x86_64 ones. setup-r v2.12.0 (2026-04-29)
+# re-enabled it, and PPM has published resolute (26.04) aarch64 CRAN binaries
+# since PPM 2026.05.0, so arm64 jobs on @v2 now install binaries, not source.
 linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
 
 include_list <- list(macos, windows, linux_devel, linux, covr, linux_arm64)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,21 +10,22 @@ Authors@R: c(
     person("cynkra GmbH", , , "mail@cynkra.com", role = "fnd",
            comment = c(ROR = "0335t7e62"))
   )
-Description: This is a private template for use by cynkra
-    packages. Please don't use it for your own package.
+Description: This is a private template for use by cynkra packages. Please
+    don't use it for your own package.
 License: MIT + file LICENSE
-URL: https://cynkratemplate.cynkra.com/, https://github.com/cynkra/cynkratemplate
+URL: https://cynkratemplate.cynkra.com/,
+    https://github.com/cynkra/cynkratemplate
 BugReports: https://github.com/cynkra/cynkratemplate/issues
+Imports: 
+    cli,
+    desc
 Suggests:
+    DBI,
     knitr,
-    rmarkdown
-VignetteBuilderNote:
-    knitr
+    rmarkdown,
+    yaml
+Config/roxygen2/version: 8.0.0.9000
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-Imports: 
-    cli,
-    desc,
-    yaml
-Config/roxygen2/version: 8.0.0.9000
+VignetteBuilderNote: knitr

--- a/R/dbi.R
+++ b/R/dbi.R
@@ -1,0 +1,19 @@
+# DBI lives in this package's Suggests purely to give the rcc-suggests
+# ("without") CI workflow a package to drop and re-check. It is a good fit
+# because it is dependency-free (base R only) and is not pulled in transitively
+# by the CI toolchain (rmarkdown / rcmdcheck / testthat), so the off_limits
+# filter in .github/workflows/dep-suggests-matrix does not exclude it -- unlike
+# cli, desc or yaml, which rmarkdown / rcmdcheck drag in. Because DBI is only in
+# Suggests, every use of it must be guarded with requireNamespace().
+
+# dbi_example() is intentionally unexported and undocumented: it exists only so
+# the package references the optional DBI dependency (conditionally), giving the
+# "without" workflow something to drop. Not meant for real use.
+dbi_example <- function() {
+  if (!requireNamespace("DBI", quietly = TRUE)) {
+    return(NULL)
+  }
+
+  # Dummy usage: touch a DBI symbol so the dependency is genuinely exercised.
+  is.function(DBI::dbGetQuery)
+}

--- a/R/use_cynkra_pkgdown.R
+++ b/R/use_cynkra_pkgdown.R
@@ -35,6 +35,12 @@ use_cynkra_pkgdown <- function(pkg = getwd()) {
   desc::desc_set("Config/Needs/website" = needs)
   cat(paste(cli::symbol$tick, "Registered GHA dependency on cynkratemplate.\n"))
 
+  # yaml is only needed to (re)write the pkgdown config and lives in Suggests,
+  # so guard its use conditionally.
+  if (!requireNamespace("yaml", quietly = TRUE)) {
+    stop("The 'yaml' package is required to update the pkgdown config; please install it.")
+  }
+
   config_path <- find_pkgdown_config(pkg)
   if (is.null(config_path)) {
     meta <- list(


### PR DESCRIPTION
## What & why

Moves every GitHub Actions workflow onto **Ubuntu 26.04 "Resolute Raccoon"**, points the package repositories at the matching distro, introduces **Linux arm64** into the R version matrix (ragged), and fixes the 26.04-runner fallout found along the way.

## Ubuntu 26.04 everywhere

All `runs-on:` values move to `ubuntu-26.04` (was `ubuntu-24.04`/`22.04`/`latest`); the `document`/`style` jobs stay on `macos-latest` (native binaries). The 26.04 images (x64 and arm) are still in [public preview](https://github.com/actions/runner-images/issues/14226).

## PPM and r-universe → resolute

- **PPM**: `use-public-rspm: true` auto-detects `resolute`; PPM serves resolute binaries for x86_64 **and** arm64. `revdep.yaml`'s stale `packagemanager.rstudio.com/.../bionic` URLs are modernized to `packagemanager.posit.co/.../resolute`.
- **r-universe**: `install_runiverse()` switches `linux_distro` `noble` → `resolute`. Verified green by the `rcc dev` job.

## Ragged arm64 matrix

| Arch | Runner | R versions |
|---|---|---|
| Linux **amd64** | `ubuntu-26.04` | devel · release · oldrel-1…4 · covr(release) |
| Linux **arm64** | `ubuntu-26.04-arm` | devel · release |

R-release **and** R-devel overlap on both arches. arm64 installs CRAN **binaries** (setup-r re-enabled PPM on aarch64 in v2.12.0; PPM ships `resolute` aarch64 binaries since 2026.05.0). Verified: `rcc: ubuntu-26.04-arm (devel)` and `(4.6)` both green.

## Smoke test → arm64? No.

It commits back, deploys pkgdown and updates snapshots, so it stays on the most stable/available runner (amd64) while `ubuntu-26.04-arm` is in preview; arm64 is covered by the non-mutating `rcc-full` matrix. Revisit at GA.

## CI fix found on 26.04: `sudo -E` hardening

The 26.04 image hardened sudo so `sudo -E` no longer preserves env; `setup-r-dependencies` installs pak via `sudo -E … dir.create(Sys.getenv("R_LIB_FOR_PAK"))`, so the var was stripped → `zero-length 'path'`, failing every install-action job. Fixed with a sudoers `env_keep` drop-in in the install action.

## Package: `yaml` → Suggests, add `DBI`

- `yaml` moved from Imports to Suggests (only the optional `use_cynkra_pkgdown()` helper needs it) and guarded with `requireNamespace()`.
- `DBI` added to Suggests with dummy, conditional usage in `R/dbi.R`. Unlike `cli`/`desc`/`yaml` (transitively required by `rmarkdown`/`rcmdcheck`), `DBI` is dependency-free and survives `dep-suggests-matrix`'s off-limits filter — so the `rcc-suggests` ("without") job finally has a package to drop and re-check.
- `usethis::use_tidy_description()` applied.

## Deliberate hedges (documented inline)

- `revdep.yaml`'s `system_requirements()` stays pinned to `ubuntu-24.04` — `remotes::system_requirements()` hardcodes ≤24.04 (the `rstudio/r-system-requirements` catalog and pak already support 26.04; only the legacy `remotes` path lags). apt names are stable across LTS.

## Validation

- CI green on this branch: `rcc` smoke + `Copilot Setup Steps`. Full matrix (incl. arm64) + `rcc dev` (r-universe resolute) verified green via the stacked dry-run PR #89.
- All changed workflow YAML parse; `R CMD check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tw1nB3SzehmtvTjkwmc2v