### PR TITLE
ci: [REUSABLE HARNESS — DO NOT MERGE] dry-run every workflow on one branch

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - "cran-*"
+      # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. Exercises the r-universe
+      # "resolute" dev-dependency install path; no side effects.
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/R-CMD-check-status.yaml
+++ b/.github/workflows/R-CMD-check-status.yaml
@@ -7,6 +7,13 @@ on:
     types:
       - requested
       - completed
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: trigger on the verification branch.
+  # Its only step is gated on a workflow_run event, so on a push it skips -- no
+  # commit status is posted. (The verification rcc workflow is renamed
+  # "rcc-dryrun", so this never fires via workflow_run for the verify branch.)
+  push:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 
 name: rcc-status
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,10 @@ on:
       - release
       - next
       - cran-*
+      # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. Runs the full rcc matrix
+      # (incl. arm64 and the rcc-suggests "without" job) on every push here,
+      # with all side effects disabled.
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
   pull_request:
     branches:
       - main
@@ -48,7 +52,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.ref || github.head_ref || github.sha }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
-name: rcc
+# DRY-RUN ONLY: renamed from "rcc" so the default-branch workflow_run listeners
+# (rcc-status, commit-suggest, which key on workflows: [rcc]) never fire for
+# this branch and post commit statuses / PR comments.
+name: rcc-dryrun
 
 jobs:
   rcc-smoke:
@@ -83,7 +90,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Update status for rcc
-        if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: false # DRY-RUN: never post commit statuses
         # FIXME: Wrap into action
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -177,6 +184,7 @@ jobs:
 
       - id: commit
         uses: ./.github/workflows/commit
+        if: false # DRY-RUN: never commit/push style, roxygen or snapshot changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -185,14 +193,15 @@ jobs:
           results: ${{ runner.os }}-smoke-test
 
       - uses: ./.github/workflows/pkgdown-build
-        if: github.event_name != 'push'
+        # DRY-RUN: always build (never deploy) so pkgdown is validated w/o gh-pages
+        if: true
 
       # Deliberately deploy only on push
       # Deployment on schedule adds too much noise.
       # Deployment on pull_request is not possible because it requires a token with write permissions, which is not available in pull_request workflows for security reasons.
       # Deployment on workflow_dispatch is available via the pkgdown workflow
       - uses: ./.github/workflows/pkgdown-deploy
-        if: github.event_name == 'push'
+        if: false # DRY-RUN: never deploy the site to gh-pages
 
       # Upload sha as artifact
       - run: |
@@ -206,7 +215,7 @@ jobs:
 
       - name: Update status for rcc
         # FIXME: Wrap into action
-        if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: false # DRY-RUN: never post commit statuses
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -243,7 +252,7 @@ jobs:
 
       - name: Update status for rcc (Copilot)
         # Update status directly when triggered by Copilot or bots, since they can't dispatch workflows
-        if: always() && (github.actor == 'Copilot')
+        if: false # DRY-RUN: never post commit statuses
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -373,7 +382,9 @@ jobs:
 
     runs-on: ubuntu-26.04
 
-    if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests)) }}
+    # DRY-RUN: also run the "without" job on the verification branch so it is
+    # exercised (it only checks -- no side effects).
+    if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests) || github.ref == 'refs/heads/claude/ubuntu-26-arm64-gha-ezzy7y-verify') }}
 
     name: Without ${{ matrix.package }}
 

--- a/.github/workflows/commit-suggest.yaml
+++ b/.github/workflows/commit-suggest.yaml
@@ -5,6 +5,12 @@ on:
     workflows: ["rcc"]
     types:
       - completed
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: trigger on the verification branch
+  # so the workflow is exercised. Its job is gated on a pull_request workflow_run,
+  # so on a plain push it skips -- no PR comment is posted.
+  push:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 
 permissions:
   contents: write
@@ -13,7 +19,10 @@ permissions:
 jobs:
   commit-suggest:
     runs-on: ubuntu-26.04
-    if: github.event.workflow_run.event == 'pull_request'
+    # DRY-RUN: also run on the verification-branch push. There is no changes-patch
+    # artifact on a push, so has_diff is false and the comment steps skip -- the
+    # job runs end-to-end with no PR comment posted.
+    if: github.event.workflow_run.event == 'pull_request' || github.event_name == 'push'
 
     steps:
       - name: Show event payload

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -4,9 +4,11 @@ name: "Copilot Setup Steps"
 # allow manual testing through the repository's "Actions" tab
 on:
   workflow_dispatch:
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: run on every push to the
+  # verification branch. copilot-setup-steps has no side effects.
   push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yaml
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yaml

--- a/.github/workflows/covr/action.yml
+++ b/.github/workflows/covr/action.yml
@@ -23,6 +23,7 @@ runs:
       shell: Rscript {0}
 
     - uses: codecov/codecov-action@v5
+      if: false # DRY-RUN: run coverage locally but never upload to Codecov
       with:
         # Fail if token is given
         fail_ci_if_error: ${{ inputs.token != '' }}

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -13,8 +13,9 @@ on:
     branches:
       - main
       - master
-    paths:
-      - ".github/workflows/fledge.yaml"
+      # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. Runs on every push here (paths
+      # filter dropped); all mutating steps are disabled below.
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
   # daily run
   schedule:
   - cron: "30 0 * * *"
@@ -113,13 +114,14 @@ jobs:
         shell: bash
 
       - name: Switch to branch if branch protection is enabled
-        if: github.ref_protected == 'true' || inputs.pr == 'true' || steps.rulesets.outputs.count > 0
+        if: false # DRY-RUN: never create/force-push the fledge branch
         run: |
           git checkout -b fledge
           git push -f -u origin HEAD
         shell: bash
 
       - name: Bump version
+        if: false # DRY-RUN: never bump the version, commit, or push
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -130,7 +132,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Create and merge PR if branch protection is enabled
-        if: github.ref_protected == 'true' || inputs.pr == 'true' || steps.rulesets.outputs.count > 0
+        if: false # DRY-RUN: never create or merge a PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -145,6 +147,7 @@ jobs:
         shell: bash
 
       - name: Check release
+        if: false # DRY-RUN: never cut a release
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -15,6 +15,11 @@ on:
   # code, we are just treating it as passive data).
   # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: also run on the verification branch
+  # (runs the style check; the reviewdog suggester step is disabled below).
+  push:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 
 name: format-suggest.yaml
 
@@ -38,6 +43,7 @@ jobs:
       - uses: ./.github/workflows/style
 
       - name: Suggest
+        if: false # DRY-RUN: never post reviewdog suggestions to a PR
         uses: reviewdog/action-suggester@v1
         with:
           level: error

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,12 +7,18 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "37 2 * * *"
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: trigger on the verification branch;
+  # the actual lock-threads step is disabled below so no threads are locked.
+  push:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 
 jobs:
   lock:
     runs-on: ubuntu-26.04
     steps:
       - uses: krlmlr/lock-threads@patch-1
+        if: false # DRY-RUN: never lock issues/PRs/discussions
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: "365"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,6 +8,8 @@ on:
       - "cran-*"
       # The main branch is excluded here, it is handled by the R-CMD-check workflow.
       # This workflow is only for handling pushes to designated branches.
+      # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. Builds (never deploys) here.
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
   workflow_dispatch:
 
 name: pkgdown
@@ -49,7 +51,7 @@ jobs:
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
       - uses: ./.github/workflows/pkgdown-build
-        if: github.event_name != 'push'
+        if: true # DRY-RUN: always build
 
       - uses: ./.github/workflows/pkgdown-deploy
-        if: github.event_name == 'push'
+        if: false # DRY-RUN: never deploy to gh-pages

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,10 +1,17 @@
 on:
   issue_comment:
     types: [created]
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE: trigger on the verification branch.
+  # The /document, /style and /merge jobs gate on a comment body, so on a push
+  # they skip; only the no-op "finish" job runs. No side effects.
+  push:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 name: Commands
 jobs:
   document:
-    if: startsWith(github.event.comment.body, '/document')
+    # DRY-RUN: also run on the verification-branch push (pr-fetch/pr-push disabled below)
+    if: startsWith(github.event.comment.body, '/document') || github.event_name == 'push'
     name: document
     # macos is actually better here due to native binary packages
     runs-on: macos-latest
@@ -13,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/pr-fetch@v2
+        if: github.event_name != 'push' # DRY-RUN: no PR to fetch on a push
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: r-lib/actions/setup-r@v2
@@ -38,10 +46,12 @@ jobs:
             git commit -m 'Document'
           fi
       - uses: r-lib/actions/pr-push@v2
+        if: github.event_name != 'push' # DRY-RUN: never push commits back to a PR
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   style:
-    if: startsWith(github.event.comment.body, '/style')
+    # DRY-RUN: also run on the verification-branch push (pr-fetch/pr-push disabled below)
+    if: startsWith(github.event.comment.body, '/style') || github.event_name == 'push'
     name: style
     # macos is actually better here due to native binary packages
     runs-on: macos-latest
@@ -50,6 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: r-lib/actions/pr-fetch@v2
+        if: github.event_name != 'push' # DRY-RUN: no PR to fetch on a push
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: r-lib/actions/setup-r@v2
@@ -74,14 +85,17 @@ jobs:
             git commit -m 'Style'
           fi
       - uses: r-lib/actions/pr-push@v2
+        if: github.event_name != 'push' # DRY-RUN: never push commits back to a PR
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   merge:
-    if: startsWith(github.event.comment.body, '/merge')
+    # DRY-RUN: also run on the verification-branch push (the PR-creating step is disabled below)
+    if: startsWith(github.event.comment.body, '/merge') || github.event_name == 'push'
     name: merge
     runs-on: ubuntu-26.04
     steps:
       - name: Create and merge pull request
+        if: github.event_name != 'push' # DRY-RUN: never create/merge a PR
         run: |
           set -exo pipefail
           PR_DETAILS=$( curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} )

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - "revdep*" # never run automatically on main branch
+      # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. cynkratemplate has no reverse
+      # dependencies, so the matrix is empty and the heavy check job is skipped;
+      # setup-r is added to the matrix job below so its Rscript step works on the
+      # bare ubuntu-26.04 image (which ships no system R).
+      - claude/ubuntu-26-arm64-gha-ezzy7y-verify
 
 name: revdep
 
@@ -31,6 +36,10 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      # DRY-RUN: the bare ubuntu-26.04 image ships no system R; install one so the
+      # dependency-collection Rscript step below runs.
+      - uses: r-lib/actions/setup-r@v2
+
       # FIXME: Avoid reissuing successful jobs
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-runs
@@ -38,11 +47,16 @@ jobs:
         run: |
           package <- read.dcf("DESCRIPTION")[, "Package"][[1]]
           deps <- tools:::package_dependencies(package, reverse = TRUE, which = c("Depends", "Imports", "LinkingTo", "Suggests"))[[1]]
-          json <- paste0(
-            '{"package":[',
-            paste0('"', deps, '"', collapse = ","),
-            ']}'
-          )
+          # DRY-RUN: drop empty/NA entries so a package with no reverse deps
+          # (like cynkratemplate) yields an empty matrix. Otherwise paste0 with a
+          # NULL `deps` emits {"package":[""]}, spawning a bogus job with an empty
+          # package that fails at "Use RSPM".
+          deps <- deps[!is.na(deps) & nzchar(deps)]
+          if (length(deps) == 0) {
+            json <- '{"package":[]}'
+          } else {
+            json <- paste0('{"package":[', paste0('"', deps, '"', collapse = ","), ']}')
+          }
           writeLines(json)
           writeLines(paste0("matrix=", json), Sys.getenv("GITHUB_OUTPUT"))
         shell: Rscript {0}

--- a/.github/workflows/update-snapshots/action.yml
+++ b/.github/workflows/update-snapshots/action.yml
@@ -75,7 +75,7 @@ runs:
 
     - name: Create pull request
       # Fall through if PR, will use reviewdog/action-suggester in the commit action
-      if: ${{ steps.check-changed.outputs.changed }}
+      if: false # DRY-RUN: never open a snapshot-update PR
       id: cpr
       uses: peter-evans/create-pull-request@v8
       with:


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — reusable CI dry-run harness

Runs **every workflow in the repo on a single push, with all side effects disabled** — a safe way to watch the whole CI suite go green before merging a CI change. First built to validate the Ubuntu 26.04 / arm64 change (now merged); retargeted to `main` and kept as a reusable harness.

### How it works
On every push to the head branch, each workflow is triggered — push events use **this branch's** workflow files, unlike `workflow_run` / `schedule` / `pull_request_target`, which always use the **default branch** — and every mutating step is neutralised:

| Workflow | Runs | Side effects disabled |
|---|---|---|
| `rcc` (renamed `rcc-dryrun`) | full matrix incl. `ubuntu-26.04-arm` + the `rcc-suggests` "without" job | commit-back, all commit-status posts, pkgdown **deploy** (build still runs), Codecov upload, snapshot-update PR |
| `rcc dev` | r-universe dev install | — (read-only) |
| `pkgdown` | builds the site | deploy |
| `copilot-setup` | installs deps | — |
| `fledge` | install + news/ruleset checks | version bump, branch force-push, PR create/merge, release |
| `lock` | triggers | thread-locking action |
| `format-suggest` | style check | reviewdog PR suggester |
| `revdep` | matrix (empty → heavy job skipped; `setup-r` added so its Rscript runs) | — |
| `pr-commands` | `document`/`style`/`merge` run with `pr-fetch`/`pr-push`/PR-create disabled; `finish` no-op | git push-back, PR create/merge |
| `rcc-status`, `commit-suggest` | run, then no-op (gated on `workflow_run`/PR context) | status posts, PR comments |

`rcc` is renamed to **`rcc-dryrun`** so the default-branch `rcc-status`/`commit-suggest` (keyed on `workflows: [rcc]`) can't fire and post statuses/comments.

### How a future session reuses this
The **only per-reuse change is the branch-name token.** This branch hard-codes its own head-branch name (`claude/ubuntu-26-arm64-gha-ezzy7y-verify`) in every push trigger and in the `rcc-suggests` `if`.

1. Create a verify branch from whatever you want to validate: `git switch -c <NEW-VERIFY-BRANCH> <your-branch>`.
2. Apply this branch's `.github/` diff — it is exactly the harness patch (everything else is already on `main`):
   `git diff main..claude/ubuntu-26-arm64-gha-ezzy7y-verify -- .github | git apply`
3. Retoken in one shot:
   `git grep -l 'claude/ubuntu-26-arm64-gha-ezzy7y-verify' -- .github | xargs sed -i 's#claude/ubuntu-26-arm64-gha-ezzy7y-verify#<NEW-VERIFY-BRANCH>#g'`
4. Commit, push `<NEW-VERIFY-BRANCH>`, open a draft PR. Every push re-runs the full dry-run.

Everything else (the `rcc-dryrun` rename, the `if: false` side-effect guards, the `revdep` `setup-r` + empty-matrix fix, the covr/Codecov guard) is generic and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)