### PR TITLE
ci: [REUSABLE HARNESS — DO NOT MERGE] middle branch to test pull_request_target workflows

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -1,20 +1,17 @@
 # Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
 
 on:
-  # Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
-  # privileges, otherwise we can't set `pull-requests: write` when the pull
-  # request comes from a fork, which is our main use case (external contributors).
-  #
-  # `pull_request_target` runs in the context of the target branch (`main`, usually),
-  # rather than in the context of the pull request like `pull_request` does. Due
-  # to this, we must explicitly checkout `ref: ${{ github.event.pull_request.head.sha }}`.
-  # This is typically frowned upon by GitHub, as it exposes you to potentially running
-  # untrusted code in a context where you have elevated privileges, but they explicitly
-  # call out the use case of reformatting and committing back / commenting on the PR
-  # as a situation that should be safe (because we aren't actually running the untrusted
-  # code, we are just treating it as passive data).
-  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-  pull_request_target:
+  # CI-VERIFY / DRY-RUN ONLY -- DO NOT MERGE. The real workflow uses
+  # `pull_request_target` (elevated token for fork PRs). But pull_request_target
+  # runs the workflow file from the repo's DEFAULT branch (main), so a modified
+  # format-suggest cannot be tested via a PR without touching main. To exercise
+  # the style + reviewdog logic end-to-end, this middle branch switches the
+  # trigger to `pull_request` (which uses the PR's own workflow file) and scopes
+  # it to PRs whose base is this middle branch -- i.e. only the outermost test PR
+  # triggers it, so this middle PR itself runs no checks.
+  pull_request:
+    branches:
+      - claude/ubuntu-26-arm64-gha-ezzy7y-fmt-base
 
 name: format-suggest.yaml
 
@@ -22,9 +19,8 @@ jobs:
   format-suggest:
     name: format-suggest
     runs-on: ubuntu-26.04
-    # Only run this job if changes come from a fork.
-    # We commit changes directly on the main repository.
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    # DRY-RUN: fork-only gate removed so this runs for the same-repo test PR.
+    # (The trigger's branches filter already scopes this to the outermost PR.)
 
     permissions:
       # Required to push suggestion comments to the PR


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — reusable "middle" branch for testing `pull_request_target` workflows (e.g. format-suggest)

Testing a change to a `pull_request_target` workflow from a PR is normally impossible: **`pull_request_target` always runs the workflow file from the repo's default branch (`main`), never the PR's branch.** This branch is the workaround's *middle* layer; the outermost test PR is #91.

### How it works
It switches `format-suggest` to a **`pull_request`** trigger (which *does* use the PR's own workflow file) scoped to `branches: [<this branch>]`, and drops the fork-only `if`. Effect:
- Only a PR whose **base is this branch** triggers format-suggest → the outermost test PR #91.
- This PR itself (base `main`) matches the filter for nothing → runs no checks.

### How a future session reuses this
Per-reuse change is the branch-name token (`claude/ubuntu-26-arm64-gha-ezzy7y-fmt-base`).
1. Create a middle branch `<NEW>-fmt-base` from `main`.
2. Apply this branch's `format-suggest.yaml` edit, then point its branches filter at the new name:
   `sed -i 's#claude/ubuntu-26-arm64-gha-ezzy7y-fmt-base#<NEW>-fmt-base#g' .github/workflows/format-suggest.yaml`
3. Push; open a draft PR (base `main`) — it runs no checks. Then stack the outermost test PR on it (see #91).

The real `format-suggest` on `main` keeps `pull_request_target` + fork-only; this `pull_request` switch is test-only. DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)