### PR TITLE
fix(ci): emit empty package matrix when there are no (rev)deps

### DIFF
--- a/.github/workflows/dep-matrix/action.yml
+++ b/.github/workflows/dep-matrix/action.yml
@@ -124,11 +124,22 @@ runs:
           writeLines(paste0("::warning::", msg))
         }
 
-        json <- paste0(
-          '{"package":[',
-          paste0('"', deps, '"', collapse = ","),
-          ']}'
-        )
+        # Build the matrix JSON explicitly for the empty case: for a package with
+        # no (rev)dependencies, paste0('"', character(0), '"') collapses to the
+        # two-character string '""', so the naive construction emits
+        # {"package":[""]} (one empty-string entry) instead of an empty array.
+        # That spawns a spurious matrix job that runs install_runiverse("") and
+        # fails. Emit an empty array so the dependent matrix job is skipped when
+        # there are none.
+        if (length(deps) == 0) {
+          json <- '{"package":[]}'
+        } else {
+          json <- paste0(
+            '{"package":[',
+            paste0('"', deps, '"', collapse = ","),
+            ']}'
+          )
+        }
         writeLines(json)
         writeLines(paste0("matrix=", json), Sys.getenv("GITHUB_OUTPUT"))
       shell: Rscript {0}

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -38,11 +38,22 @@ jobs:
         run: |
           package <- read.dcf("DESCRIPTION")[, "Package"][[1]]
           deps <- tools:::package_dependencies(package, reverse = TRUE, which = c("Depends", "Imports", "LinkingTo", "Suggests"))[[1]]
-          json <- paste0(
-            '{"package":[',
-            paste0('"', deps, '"', collapse = ","),
-            ']}'
-          )
+          # Build the matrix JSON explicitly for the empty case: for a package with
+          # no (rev)dependencies, paste0('"', character(0), '"') collapses to the
+          # two-character string '""', so the naive construction emits
+          # {"package":[""]} (one empty-string entry) instead of an empty array.
+          # That spawns a spurious matrix job that runs install_runiverse("") and
+          # fails. Emit an empty array so the dependent matrix job is skipped when
+          # there are none.
+          if (length(deps) == 0) {
+            json <- '{"package":[]}'
+          } else {
+            json <- paste0(
+              '{"package":[',
+              paste0('"', deps, '"', collapse = ","),
+              ']}'
+            )
+          }
           writeLines(json)
           writeLines(paste0("matrix=", json), Sys.getenv("GITHUB_OUTPUT"))
         shell: Rscript {0}


### PR DESCRIPTION
## Problem

Both the `dep-matrix` composite action and the `revdep` workflow build their matrix JSON like this:

```r
json <- paste0('{"package":[', paste0('"', deps, '"', collapse = ","), ']}')
```

When `deps` is empty — a package with **no dev dependencies** (`dep-matrix`) or **no reverse dependencies** (`revdep`) — `paste0('"', character(0), '"')` collapses to the two-character string `""`, so the output becomes `{"package":[""]}`: a matrix with **one empty-string entry** instead of an empty array. That spawns a spurious matrix job that runs `remotes::install_runiverse("")` (or checks package `""`), which fails with `JSON: EXPECTED value GOT E`.

This is the shared-template source of the bug that was first patched per-repo in **cynkra/dd#25** — and then re-introduced when a later `ci: Align workflows with template` sync overwrote that per-repo fix. Fixing it here stops it recurring for every dependency-free (or revdep-free) package on the next sync.

## Fix

Guard the empty case explicitly in both files and emit `{"package":[]}`, so a dynamic matrix of zero jobs is produced (and the dependent job is skipped) when there are no (rev)dependencies:

```r
if (length(deps) == 0) {
  json <- '{"package":[]}'
} else {
  json <- paste0('{"package":[', paste0('"', deps, '"', collapse = ","), ']}')
}
```

- `.github/workflows/dep-matrix/action.yml`
- `.github/workflows/revdep.yaml`

## Verification

- Both files validated with `yaml.safe_load`.
- JSON logic: empty `deps` → `{"package":[]}`; non-empty → `{"package":["DBI",...]}` unchanged.
- No other behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_