### PR TITLE
ci: Harden `format-suggest` against `pull_request_target` pwn requests

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -1,22 +1,41 @@
 # Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
 
 on:
-  # Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
-  # privileges, otherwise we can't set `pull-requests: write` when the pull
-  # request comes from a fork, which is our main use case (external contributors).
+  # We keep `pull_request_target` (rather than `pull_request`) so that this job
+  # can post review suggestions on pull requests that come from forks, which is
+  # our main use case. A fork's `pull_request` run only gets a read-only token,
+  # so it cannot comment; `pull_request_target` runs with the base repository's
+  # token and can be granted `pull-requests: write`.
   #
-  # `pull_request_target` runs in the context of the target branch (`main`, usually),
-  # rather than in the context of the pull request like `pull_request` does. Due
-  # to this, we must explicitly checkout `ref: ${{ github.event.pull_request.head.sha }}`.
-  # This is typically frowned upon by GitHub, as it exposes you to potentially running
-  # untrusted code in a context where you have elevated privileges, but they explicitly
-  # call out the use case of reformatting and committing back / commenting on the PR
-  # as a situation that should be safe (because we aren't actually running the untrusted
-  # code, we are just treating it as passive data).
+  # SECURITY -- this is a classic "pwn request" surface, so the fork's code is
+  # treated strictly as *data to be formatted*, never as code to run:
+  #
+  #   1. The formatter tooling (the `style` action and the air / clang-format
+  #      binaries) is loaded from the BASE repository, not from the PR checkout.
+  #      This is the critical point. The naive pattern
+  #        - uses: actions/checkout@v6      # ref: fork head
+  #        - uses: ./.github/workflows/style
+  #      resolves `./...style` from the *checked-out fork*, so an attacker only
+  #      has to edit their fork's `style/action.yml` to run arbitrary commands
+  #      with our token and secrets. Here we run the base repo's copy instead
+  #      (checked out into `ci-base/`), so the fork controls only the input
+  #      files, not the code that executes.
+  #   2. air and clang-format merely parse and re-print source; they do not
+  #      evaluate it. No build / install / test step ever runs the fork's code.
+  #   3. The PR is checked out with `persist-credentials: false`, so the token
+  #      is not written to disk alongside untrusted files.
+  #   4. Permissions are reduced to `pull-requests: write` only, and
+  #      `harden-runner` observes (and can block) network egress.
+  #
   # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  # https://gh.io/securely-using-pull_request_target
   pull_request_target:
 
 name: format-suggest.yaml
+
+# Deny everything by default; the job below opts back into the single scope it
+# needs. This caps the blast radius of the elevated `pull_request_target` token.
+permissions: {}
 
 jobs:
   format-suggest:
@@ -31,11 +50,40 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      # Defense in depth: monitor outbound network traffic from the runner.
+      # Switch `egress-policy` to `block` (with an `allowed-endpoints` list) to
+      # hard-fail on any connection outside the formatter tool downloads; run
+      # once in `audit` first to capture the exact endpoints to allow.
+      - name: Harden runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      # The untrusted PR code, checked out at the workspace root. It is DATA
+      # only -- nothing below executes it. `allow-unsafe-pr-checkout` is required
+      # by actions/checkout@v6 for a fork ref under pull_request_target; it is
+      # safe here specifically because the code that runs comes from `ci-base/`
+      # (the base repo), never from this checkout. See the security notes above.
+      - name: Check out PR code (treated as data)
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
-      - uses: ./.github/workflows/style
+      # The trusted formatter tooling, from the base repository, into a separate
+      # directory the fork cannot influence.
+      - name: Check out trusted tooling from base repo
+        uses: actions/checkout@v6
+        with:
+          path: ci-base
+          persist-credentials: false
+
+      # Runs the base repo's `style` action against the PR code at the workspace
+      # root. Because the action comes from `ci-base/`, the fork controls only
+      # the files being formatted, not the code that runs.
+      - name: Format
+        uses: ./ci-base/.github/workflows/style
 
       - name: Suggest
         uses: reviewdog/action-suggester@v1


### PR DESCRIPTION
## Problem

`format-suggest.yaml` runs on `pull_request_target` (deliberately — it needs a write-scoped token to comment on fork PRs). As written it did:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.event.pull_request.head.sha }}   # fork head
- uses: ./.github/workflows/style
```

The intent was "we only *format*, we never *execute* the fork's code." But `uses: ./.github/workflows/style` resolves the composite action **from the checked-out fork**. An attacker opening a PR from a fork only has to edit their own `.github/workflows/style/action.yml` to run arbitrary commands — with our `GITHUB_TOKEN` and any secrets, in the base-repo context. That's full remote code execution, not formatting. This is exactly why `actions/checkout@v6` now refuses the fork checkout under `pull_request_target` ("Refusing to check out fork pull request code…").

## Fix — adapt, keep formatting-only, actually never execute

The workflow is kept (still `pull_request_target`, still posts reviewdog suggestions on fork PRs), but the fork's code is now treated strictly as **data to be formatted**:

1. **Tooling comes from the base repo, not the PR.** The base repository is checked out into `ci-base/`, and we run `./ci-base/.github/workflows/style`. The PR checkout stays at the workspace root (so reviewdog's diff paths line up with the PR), but the fork now controls only the *files being formatted*, never the *code that runs*. `air` and `clang-format` parse and re-print source — they don't evaluate it.
2. **`persist-credentials: false`** on the PR checkout so the token isn't written to disk next to untrusted files.
3. **Least privilege:** top-level `permissions: {}` (deny all), job grants only `pull-requests: write`.
4. **`step-security/harden-runner`** to observe network egress (starts in `audit`; can be flipped to `block` with an allow-list once the formatter download endpoints are captured).
5. **`allow-unsafe-pr-checkout: true`** — now justified: with the above, the checkout is a pure data fetch and nothing executes the fork's code.

## Changes

- **`.github/workflows/format-suggest.yaml`** only. No change to the `rcc` / `commit-suggest` pipeline.

## Threat model notes for reviewers

- **Primary hole closed:** fork-controlled action execution (item 1). This was the RCE.
- **Residual, now-mitigated risks:** token on disk (→ `persist-credentials: false`), over-broad token scope (→ minimal `permissions`), exfiltration / second-stage fetch if a formatter ever mis-behaved (→ `harden-runner`).
- **Accepted low risks:** a malicious `air.toml` / `.clang-format` is formatter *config*, not executable code; the base-scoped cache is keyed on tool version, not fork content.
- **Network egress:** shipped as `audit` so it can't silently break tool installs; switching to `block` + `allowed-endpoints` is a one-line follow-up once endpoints are confirmed. Happy to do that here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYkUWKeajajgrmJ9gos2KU