### PR TITLE
ci: Apply matrix `env` vars in the workflow, not in custom actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -317,12 +317,23 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
+      - name: Apply environment variables from the test matrix
+        # Generic: matrix entries defined in .github/versions-matrix.R can
+        # carry an "env" field (one KEY=VALUE per line).
+        # Write it to $GITHUB_ENV here, in the workflow,
+        # because composite actions cannot read the matrix context.
+        # The variables then reach every subsequent step,
+        # including the custom before-install and after-install actions,
+        # without requiring repos to implement any plumbing of their own.
+        if: matrix.env != ''
+        env:
+          MATRIX_ENV: ${{ matrix.env }}
+        run: |
+          printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
+        shell: bash
+
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
-        with:
-          # Generic: forward any per-entry environment variables defined in the
-          # test matrix (see .github/versions-matrix.R) to the custom action.
-          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -67,9 +67,18 @@ if (!is.na(filter)) {
 
 to_json <- function(x) {
   if (nrow(x) == 0) return(character())
+  # Minimal JSON string escaping: backslash, double quote, newline.
+  # Newlines matter for the "env" field,
+  # which carries one KEY=VALUE per line.
+  escape <- function(v) {
+    v <- gsub("\\", "\\\\", v, fixed = TRUE)
+    v <- gsub('"', '\\"', v, fixed = TRUE)
+    v <- gsub("\n", "\\n", v, fixed = TRUE)
+    v
+  }
   parallel <- vector("list", length(x))
   for (i in seq_along(x)) {
-    parallel[[i]] <- paste0('"', names(x)[[i]], '":"', x[[i]], '"')
+    parallel[[i]] <- paste0('"', escape(names(x)[[i]]), '":"', escape(x[[i]]), '"')
   }
   paste0("{", do.call(paste, c(parallel, sep = ",")), "}")
 }


### PR DESCRIPTION
## Problem

Matrix entries in `.github/versions-matrix.R` can carry a generic `env` field
(one `KEY=VALUE` per line).
Until now, the `rcc-full` job only *forwarded* that field
to the custom before-install action as an input:

```yaml
- uses: ./.github/workflows/custom/before-install
  with:
    env: ${{ matrix.env }}
```

Because composite actions cannot read the `matrix` context,
every consumer repo had to implement the same apply-to-`$GITHUB_ENV` boilerplate
in its own `.github/workflows/custom/before-install/action.yml`
(dm, duckdb-r, and rigraph each carry an identical copy today),
and a repo without that boilerplate silently drops the variables.

The claim that surfaced in igraph/rigraph —
"a before-install action is needed to pick up the environment variable" —
was therefore true for **all** consumer repos, not just rigraph.
It is an artifact of the template design, not of that repo.

CI logs confirm the failure mode for matrix values
referenced *directly* inside composite actions:
in cynkra/dm's "SQL Server with covr" job,
`DM_TEST_SRC` (set from `${{ matrix.config.test-src }}` inside the composite action)
comes out empty, while the forwarded-input route (`DM_VALIDATE=true`) works.

## Fix

* Apply the `env` field directly in the `rcc-full` job,
  before the custom before-install action runs,
  so the variables reach every subsequent step —
  including the custom before-install and after-install actions —
  in all repos, with no custom amendments needed.
* Drop the now-redundant `env` input forwarding.
* Escape backslash, double quote, and newline
  in the JSON emitted by `versions-matrix/action.R`,
  so multi-line `env` values (one `KEY=VALUE` per line)
  survive the trip through the matrix JSON.

## Companion PRs

* igraph/rigraph#2798 — sync + drop the apply boilerplate
* cynkra/dm#2486 — sync + drop boilerplate;
  also restores the six database-backend runs,
  which had been silently testing plain data frames
* duckdb/duckdb-r#2422 — sync + drop boilerplate
  (branch also pushed to `krlmlr/duckdb-r`)
* r-dbi/RMariaDB#547 — sync only;
  documents that its `matrix.config.*`-based client/server switches are inert
* r-dbi/RPostgres#592 — sync only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136C9bRMjBGkUrtLdkYNmAg