### PR TITLE
ci: Link the responsible workflow run in snapshot update PRs

### DIFF
--- a/.github/workflows/update-snapshots/action.yml
+++ b/.github/workflows/update-snapshots/action.yml
@@ -83,7 +83,16 @@ runs:
         branch: snapshot-${{ inputs.base }}-${{ github.job }}-${{ steps.matrix-desc.outputs.branch }}
         delete-branch: true
         title: "test: Snapshot updates for ${{ github.job }} (${{ steps.matrix-desc.outputs.text }})"
-        body: "Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action${{ github.event.number && format(' for #{0}', github.event.number) || '' }}."
+        # Two consecutive blank lines in the folded scalar produce the
+        # paragraph break between the sentence and the run link.
+        body: >-
+          Automated changes by
+          [create-pull-request](https://github.com/peter-evans/create-pull-request)
+          GitHub action${{ github.event.number && format(' for #{0}', github.event.number) || '' }}.
+
+
+          Workflow run:
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         add-paths: |
           tests/testthat/_snaps
 


### PR DESCRIPTION
The `update-snapshots` action creates snapshot-update PRs
whose body only said
"Automated changes by create-pull-request GitHub action",
leaving no trace of which workflow run produced them.
Identifying the run behind igraph/rigraph#2796, for example,
required correlating timestamps across ~20 concurrent runs
and reading job logs.

The PR body now carries a second paragraph
linking the responsible run,
built from `github.server_url`, `github.repository`, and `github.run_id`,
which are all available inside composite actions.
When a later run updates an existing snapshot PR,
`create-pull-request` rewrites the body,
so the link always points at the run responsible
for the PR's current state.

The link targets the run rather than the individual matrix job:
the numeric job id is not exposed in the Actions context,
and the PR title already names the job and matrix entry,
which locates the job on the run page in one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ19YEpwhATcBtFgew82Fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ19YEpwhATcBtFgew82Fk)_