### PR TITLE
ci: Run all smoke-test checks even when one fails

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -139,7 +139,12 @@ jobs:
           _R_SHLIB_STRIP_=true R CMD INSTALL .
         shell: bash
 
+      # From here on, every step is marked `continue-on-error: true` so that a
+      # failing check doesn't hide the results of all the checks that follow.
+      # The "Summarize checks" step at the end fails the job if any of them
+      # did not succeed.
       - id: versions-matrix
+        continue-on-error: true
         # Only run for:
         # - pull requests if the base repo is different from the head repo
         # - pull requests if the branch name starts with "cran-"
@@ -150,6 +155,7 @@ jobs:
         uses: ./.github/workflows/versions-matrix
 
       - id: dep-suggests-matrix
+        continue-on-error: true
         # Not for workflow_dispatch if not requested, always run for other events
         if: github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
         uses: ./.github/workflows/dep-suggests-matrix
@@ -159,16 +165,22 @@ jobs:
         uses: ./.github/workflows/repo-state
 
       # Styling on foreign PRs works through the format-suggest workflow
-      - uses: ./.github/workflows/style
+      - id: style
+        continue-on-error: true
+        uses: ./.github/workflows/style
         if: steps.repo-state.outputs.foreign != 'true' || steps.repo-state.outputs.is_pr != 'true'
 
       # Snapshot tests can't work in a way similar to format-suggests
       # because it requires running code which is a security risk on pull_request_target workflows
-      - uses: ./.github/workflows/update-snapshots
+      - id: snapshots
+        continue-on-error: true
+        uses: ./.github/workflows/update-snapshots
         with:
           base: ${{ inputs.ref || github.head_ref }}
 
-      - uses: ./.github/workflows/roxygenize
+      - id: roxygenize
+        continue-on-error: true
+        uses: ./.github/workflows/roxygenize
 
       - name: Remove config files from previous iteration
         run: |
@@ -176,23 +188,32 @@ jobs:
         shell: bash
 
       - id: commit
+        continue-on-error: true
         uses: ./.github/workflows/commit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/workflows/check
+      - id: check
+        continue-on-error: true
+        uses: ./.github/workflows/check
         with:
           results: ${{ runner.os }}-smoke-test
 
-      - uses: ./.github/workflows/pkgdown-build
+      - id: pkgdown-build
+        continue-on-error: true
+        uses: ./.github/workflows/pkgdown-build
         if: github.event_name != 'push'
 
       # Deliberately deploy only on push
       # Deployment on schedule adds too much noise.
       # Deployment on pull_request is not possible because it requires a token with write permissions, which is not available in pull_request workflows for security reasons.
       # Deployment on workflow_dispatch is available via the pkgdown workflow
-      - uses: ./.github/workflows/pkgdown-deploy
-        if: github.event_name == 'push'
+      # Deploying a broken package's website is worse than not deploying at all,
+      # hence this is the one step that is still gated on a check.
+      - id: pkgdown-deploy
+        continue-on-error: true
+        uses: ./.github/workflows/pkgdown-deploy
+        if: github.event_name == 'push' && steps.check.outcome == 'success'
 
       # Upload sha as artifact
       - run: |
@@ -203,6 +224,47 @@ jobs:
         with:
           name: rcc-smoke-sha
           path: rcc-smoke-sha.txt
+
+      # This is the step that fails the job if any of the checks above failed
+      - name: Summarize checks
+        if: always()
+        run: |
+          ## -- Summarize checks --
+          status=0
+
+          report() {
+            outcome="${2:-skipped}"
+            case "${outcome}" in
+              success) icon="✅" ;;
+              skipped) icon="⏭️" ;;
+              *) icon="❌" ; status=1 ;;
+            esac
+            echo "| ${1} | ${icon} ${outcome} |" >> "${GITHUB_STEP_SUMMARY}"
+          }
+
+          {
+            echo "## Smoke test summary"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          report "R versions matrix" "${{ steps.versions-matrix.outcome }}"
+          report "Suggested dependencies matrix" "${{ steps.dep-suggests-matrix.outcome }}"
+          report "Style" "${{ steps.style.outcome }}"
+          report "Snapshots" "${{ steps.snapshots.outcome }}"
+          report "Roxygenize" "${{ steps.roxygenize.outcome }}"
+          report "Commit" "${{ steps.commit.outcome }}"
+          report "R CMD check" "${{ steps.check.outcome }}"
+          report "pkgdown build" "${{ steps.pkgdown-build.outcome }}"
+          report "pkgdown deploy" "${{ steps.pkgdown-deploy.outcome }}"
+
+          if [ "${status}" -ne 0 ]; then
+            printf '\nAt least one check failed, see the log for details.\n' >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          exit "${status}"
+        shell: bash
 
       - name: Update status for rcc
         # FIXME: Wrap into action


### PR DESCRIPTION
## Problem

The `rcc-smoke` job ran its checks as a plain step sequence,
so the first failure skipped everything after it.
Failing snapshot tests hid the `R CMD check` result,
a failing `R CMD check` hid the pkgdown build, and so on.
Each run only ever reported the first problem,
which turned a single red run into several round trips.

## Change

Every step after `R CMD INSTALL .` is now marked `continue-on-error: true`:
versions matrix, suggests matrix, style, snapshots, roxygenize,
commit, `R CMD check`, pkgdown build, pkgdown deploy.
Installation stays the hard gate —
if it fails, nothing downstream runs, as before.

A final `Summarize checks` step (`if: always()`) reads each step's `outcome`,
writes a Markdown table to `$GITHUB_STEP_SUMMARY`,
and exits non-zero if any check did not succeed.
That step is what fails the job now.

```
## Smoke test summary

| Check | Result |
| --- | --- |
| Style | ✅ success |
| Snapshots | ❌ failure |
| R CMD check | ❌ failure |
| pkgdown deploy | ⏭️ skipped |

At least one check failed, see the log for details.
```

A step that never ran reports an empty `outcome`,
which the summary maps to `skipped` rather than counting as a pass.

## One deliberate exception

`pkgdown-deploy` keeps a gate:
`if: github.event_name == 'push' && steps.check.outcome == 'success'`.
Without it, `continue-on-error` would mean that a push to `main`
publishes the website of a package whose `R CMD check` just failed —
previously prevented by the very sequencing this PR removes.
Every other step is ungated.

## Side effects worth reviewing

- The `rcc-smoke-sha` artifact now uploads on failing runs too,
  so `rcc-status` attaches the failure status to the auto-generated commit
  instead of falling back to `head_sha`.
  This is more accurate, since the style and roxygen updates
  are part of what was checked.
- If the snapshot updater opens a snapshot PR (protected-branch path),
  the `commit` step now runs afterwards instead of being skipped.
  `peter-evans/create-pull-request` force-checks-out the base branch on exit,
  so the tree should be clean and `commit` a no-op,
  but this path only exercises on a real push to `main` and is unverified here.

`R-CMD-check-dev.yaml` has the same `update-snapshots` → `check` sequencing,
but is left alone:
those are `fail-fast: false` matrix jobs that do not mutate the repository.

https://claude.ai/code/session_01ETPVyEv71RVEKcD5VGnQfq