### PR TITLE
ci: Add sharded `revdep2` workflow

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -68,9 +68,6 @@ jobs:
       contents: write
       pull-requests: write
 
-    # Begin custom: services
-    # End custom: services
-
     strategy:
       fail-fast: false
 
@@ -118,9 +115,6 @@ jobs:
       # Both required by the update-snapshots action.
       contents: write
       pull-requests: write
-
-    # Begin custom: services
-    # End custom: services
 
     strategy:
       fail-fast: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -80,9 +80,6 @@ jobs:
       pull-requests: write
       actions: write
 
-    # Begin custom: services
-    # End custom: services
-
     steps:
       - uses: actions/checkout@v6
         with:
@@ -391,9 +388,6 @@ jobs:
       contents: write
       pull-requests: write
 
-    # Begin custom: services
-    # End custom: services
-
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
@@ -480,9 +474,6 @@ jobs:
 
     permissions:
       contents: read
-
-    # Begin custom: services
-    # End custom: services
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -28,9 +28,6 @@ jobs:
       # Required by pkgdown::deploy_to_branch(), which pushes to gh-pages
       contents: write
 
-    # Begin custom: services
-    # End custom: services
-
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -23,8 +23,6 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
-      # Begin custom: env vars
-      # End custom: env vars
 
     steps:
       - name: Check rate limits
@@ -88,9 +86,6 @@ jobs:
 
     name: 'revdep: ${{ matrix.package }}'
 
-    # Begin custom: services
-    # End custom: services
-
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
@@ -101,8 +96,6 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
-      # Begin custom: env vars
-      # End custom: env vars
 
     steps:
       - name: Check rate limits
@@ -113,9 +106,6 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@v6
-
-      # Begin custom: before install
-      # End custom: before install
 
       - name: Use RSPM
         run: |
@@ -157,9 +147,6 @@ jobs:
           pkgs <- installed.packages()[, "Package"]
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
-
-      # Begin custom: after install
-      # End custom: after install
 
       - name: Check old
         env:

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -1,17 +1,19 @@
-# Sharded reverse-dependency check: plan -> build -> test (matrix) -> collect.
+# Sharded reverse-dependency check:
+# plan + build (parallel) -> preflight -> test (matrix) -> collect.
 #
-# The plan job enumerates the CRAN reverse dependencies of this package, weighs
-# each one by the time CRAN's own Linux check machine spends on it, decides
-# which CRAN-baseline results from an earlier run are still valid, and deals
-# the packages into cost-balanced shards -- the heaviest round-robin first,
-# everything else placed where it shares the most dependencies (see
-# revdep2/README.md for the algorithm and its trade-offs).
+# The plan job enumerates the CRAN reverse dependencies of this package (to
+# any depth), weighs each one by the time CRAN's own Linux check machine
+# spends on it, decides which CRAN-baseline results from an earlier run are
+# still valid, and deals the packages into cost-balanced shards -- the
+# heaviest round-robin first, everything else placed where it shares the most
+# dependencies (see revdep2/README.md for the algorithm and its trade-offs).
 #
-# The build job compiles the dev version once into a binary artifact every
-# shard installs, and preflights the whole dependency universe -- install and
-# load every package any revdep needs -- so broken dependencies surface before
-# the first check minute is spent, and the pak cache the shards restore is
-# warm.
+# The build job compiles the dev version once into the binary artifact every
+# shard installs; it needs only the checkout, so it runs in parallel with
+# planning. The preflight job installs and loads the whole dependency
+# universe -- every package any revdep needs -- so broken dependencies surface
+# before the first check minute is spent, and the pak cache the shards restore
+# is warm.
 #
 # Each test shard installs its dependency union, checks every one of its
 # packages against the CRAN version (or reuses a baseline), swaps in the dev
@@ -37,13 +39,21 @@
 # To re-check only what a run could not declare ok, dispatch again with
 # `retry-run: <run-id>`; the new report carries the old run's good results
 # over, so it is complete again.
+#
+# Dispatch-only, deliberately: nothing here runs on push. `ref` checks any
+# branch, tag or commit SHA (the dispatch itself can only target a branch or
+# tag, and the tree must contain these scripts), `depth` widens the net to
+# transitive reverse dependencies, and `dry-run` stops after planning. Check
+# results never turn the run red -- the summary and the report artifact are
+# the deliverable; only infrastructure failures fail jobs.
 
 on:
-  push:
-    branches:
-      - "revdep2*" # never run automatically on main branch
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to check (the tree must contain the revdep2 scripts); default: the dispatched ref"
+        type: string
+        default: ""
       packages:
         description: "Packages to check (comma/space separated; default: all reverse dependencies)"
         type: string
@@ -55,6 +65,10 @@ on:
           - strong
           - most
         default: strong
+      depth:
+        description: "Levels of reverse dependencies: 1 = direct, 2 = also revdeps of revdeps, ..., 'all' = the full transitive closure"
+        type: string
+        default: "1"
       retry-run:
         description: "Run id of an earlier revdep2 run; re-check only its not-ok packages"
         type: string
@@ -75,35 +89,35 @@ on:
         description: "Oldest baseline result worth reusing"
         type: string
         default: ""
-      fail-on:
-        description: "When the collect job turns the run red"
-        type: choice
-        options:
-          - newly-broken
-          - any
-          - none
-        default: newly-broken
+      dry-run:
+        description: "Plan only: report the shards and reuse decisions, start no checks"
+        type: boolean
+        default: false
 
 name: revdep2
 
-# One planning pass per branch at a time; a queued run waits rather than
+# One planning pass per checked ref at a time; a queued run waits rather than
 # killing shards mid-check, because a killed shard's unfinished packages would
 # have to be re-planned and re-checked.
 concurrency:
-  group: revdep2-${{ github.ref }}
+  group: revdep2-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
 
 env:
   REVDEP2_PACKAGES: ${{ inputs.packages || '' }}
   REVDEP2_WHICH: ${{ inputs.which || 'strong' }}
+  REVDEP2_DEPTH: ${{ inputs.depth || '1' }}
   REVDEP2_RETRY_RUN: ${{ inputs.retry-run || '' }}
   REVDEP2_SHARD_BUDGET_MINUTES: ${{ inputs.shard-budget-minutes || vars.REVDEP2_SHARD_BUDGET_MINUTES || '45' }}
   REVDEP2_MAX_PARALLEL: ${{ inputs.max-parallel || vars.REVDEP2_MAX_PARALLEL || '20' }}
   REVDEP2_REFRESH_BASELINE: ${{ inputs.refresh-baseline && '1' || '' }}
   REVDEP2_BASELINE_MAX_AGE_DAYS: ${{ inputs.baseline-max-age-days || vars.REVDEP2_BASELINE_MAX_AGE_DAYS || '30' }}
-  REVDEP2_CHECK_TIMEOUT_MINUTES: ${{ vars.REVDEP2_CHECK_TIMEOUT_MINUTES || '30' }}
+  REVDEP2_DRY_RUN: ${{ inputs.dry-run && '1' || '' }}
+  # Per-check timeout: factor times the package's CRAN check time, but never
+  # below the floor -- CRAN's machines are not these runners.
+  REVDEP2_TIMEOUT_FACTOR: ${{ vars.REVDEP2_TIMEOUT_FACTOR || '1.5' }}
+  REVDEP2_TIMEOUT_MIN_MINUTES: ${{ vars.REVDEP2_TIMEOUT_MIN_MINUTES || '10' }}
   REVDEP2_DEADLINE_MINUTES: ${{ vars.REVDEP2_DEADLINE_MINUTES || '300' }}
-  REVDEP2_FAIL_ON: ${{ inputs.fail-on || 'newly-broken' }}
 
 jobs:
   plan:
@@ -130,6 +144,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -158,14 +174,14 @@ jobs:
           overwrite: true
 
   build:
-    needs:
-      - plan
-
-    if: needs.plan.outputs.shards != '0'
+    # No needs: the binary depends only on the checkout, so this runs in
+    # parallel with planning and costs no wall clock of its own. Only the
+    # shards consume its artifact; a dry run skips it.
+    if: inputs.dry-run != true
 
     runs-on: ubuntu-26.04
 
-    name: "Build binary, preflight dependencies"
+    name: "Build the dev binary"
 
     permissions:
       contents: read
@@ -175,6 +191,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       # Begin custom: before install
       # End custom: before install
@@ -184,6 +202,53 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: revdep2-1
           needs: build
+
+      - name: Build the binary
+        env:
+          OUT_DIR: ${{ runner.temp }}/pkg
+        run: |
+          Rscript ./.github/workflows/revdep2/build.R
+        shell: bash
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: revdep2-pkg
+          path: ${{ runner.temp }}/pkg
+          retention-days: 30
+          overwrite: true
+
+  preflight:
+    needs:
+      - plan
+
+    # A dry run stops after planning; skipping preflight cascades to test and,
+    # through the `needs.*.result == 'success'` guards, to collect.
+    if: needs.plan.outputs.shards != '0' && inputs.dry-run != true
+
+    runs-on: ubuntu-26.04
+
+    name: "Preflight all dependencies"
+
+    permissions:
+      contents: read
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install pak and jsonlite
+        run: |
+          install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
+          install.packages("jsonlite")
+        shell: Rscript {0}
 
       - uses: actions/download-artifact@v6
         with:
@@ -199,19 +264,19 @@ jobs:
           restore-keys: |
             revdep2-pak-
 
-      - name: Build binary and preflight dependencies
+      - name: Install and load every dependency
         env:
           PLAN: ${{ runner.temp }}/plan/plan.json
-          OUT_DIR: ${{ runner.temp }}/pkg
+          OUT_DIR: ${{ runner.temp }}/preflight
           PKG_SYSREQS: true
         run: |
-          Rscript ./.github/workflows/revdep2/build.R
+          Rscript ./.github/workflows/revdep2/preflight.R
         shell: bash
 
       - uses: actions/upload-artifact@v5
         with:
-          name: revdep2-pkg
-          path: ${{ runner.temp }}/pkg
+          name: revdep2-preflight
+          path: ${{ runner.temp }}/preflight
           retention-days: 30
           overwrite: true
 
@@ -219,6 +284,7 @@ jobs:
     needs:
       - plan
       - build
+      - preflight
 
     if: needs.plan.outputs.shards != '0'
 
@@ -257,6 +323,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -316,7 +384,8 @@ jobs:
           PKG_DIR: ${{ runner.temp }}/pkg
           BASELINE_DIR: ${{ runner.temp }}/baseline
           OUT_DIR: ${{ runner.temp }}/results
-          CHECK_TIMEOUT_MINUTES: ${{ env.REVDEP2_CHECK_TIMEOUT_MINUTES }}
+          TIMEOUT_FACTOR: ${{ env.REVDEP2_TIMEOUT_FACTOR }}
+          TIMEOUT_MIN_MINUTES: ${{ env.REVDEP2_TIMEOUT_MIN_MINUTES }}
           DEADLINE_MINUTES: ${{ env.REVDEP2_DEADLINE_MINUTES }}
           PKG_SYSREQS: true
         run: |
@@ -338,13 +407,14 @@ jobs:
     needs:
       - plan
       - build
+      - preflight
       - test
 
     # `always()` so a run with red shards still reports -- a broken revdep is
-    # the result this workflow exists to surface. Guarded on plan and build
-    # having succeeded, because without a plan or a binary there is nothing to
-    # collect.
-    if: always() && needs.plan.result == 'success' && needs.build.result == 'success' && needs.plan.outputs.shards != '0'
+    # the result this workflow exists to surface. Guarded on the earlier
+    # stages having succeeded, because without a plan and a binary there is
+    # nothing to collect; a dry run skips preflight and therefore this too.
+    if: always() && needs.plan.result == 'success' && needs.build.result == 'success' && needs.preflight.result == 'success' && needs.plan.outputs.shards != '0'
 
     runs-on: ubuntu-26.04
 
@@ -359,6 +429,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -406,7 +478,6 @@ jobs:
           RETRY_DIR: ${{ runner.temp }}/retry-report
           OUT_DIR: revdep
           BASELINE_OUT: ${{ runner.temp }}/baseline
-          FAIL_ON: ${{ env.REVDEP2_FAIL_ON }}
         run: |
           Rscript ./.github/workflows/revdep2/collect.R
         shell: bash

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -1,0 +1,428 @@
+# Sharded reverse-dependency check: plan -> build -> test (matrix) -> collect.
+#
+# The plan job enumerates the CRAN reverse dependencies of this package, weighs
+# each one by the time CRAN's own Linux check machine spends on it, decides
+# which CRAN-baseline results from an earlier run are still valid, and deals
+# the packages into cost-balanced shards -- the heaviest round-robin first,
+# everything else placed where it shares the most dependencies (see
+# revdep2/README.md for the algorithm and its trade-offs).
+#
+# The build job compiles the dev version once into a binary artifact every
+# shard installs, and preflights the whole dependency universe -- install and
+# load every package any revdep needs -- so broken dependencies surface before
+# the first check minute is spent, and the pak cache the shards restore is
+# warm.
+#
+# Each test shard installs its dependency union, checks every one of its
+# packages against the CRAN version (or reuses a baseline), swaps in the dev
+# binary, checks again, and compares -- revdepcheck-style, one manifest line
+# and a pair of rcmdcheck results per package. A broken package is a result,
+# never a job failure; the shard defers what its deadline cannot fit and says
+# so.
+#
+# The collect job folds every shard artifact (and, on a retry, the untouched
+# results of the run being retried) into revdepcheck-style reports (README.md,
+# problems.md, failures.md, cran.md), a machine-readable manifest, and the
+# baseline artifact future runs reuse to skip unchanged CRAN checks.
+#
+# Results land in artifacts:
+#   revdep2-report    the merged report -- fetch with
+#                     `gh run download <run-id> --name revdep2-report`
+#                     or ./.github/workflows/revdep2/fetch.sh <run-id>
+#   revdep2-baseline  old-version results, reused by later runs when the
+#                     revdep's version, our CRAN version, the R series and the
+#                     resolved dependency versions all still match (and the
+#                     result is younger than baseline-max-age-days)
+#
+# To re-check only what a run could not declare ok, dispatch again with
+# `retry-run: <run-id>`; the new report carries the old run's good results
+# over, so it is complete again.
+
+on:
+  push:
+    branches:
+      - "revdep2*" # never run automatically on main branch
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Packages to check (comma/space separated; default: all reverse dependencies)"
+        type: string
+        default: ""
+      which:
+        description: "Which reverse dependencies to enumerate"
+        type: choice
+        options:
+          - strong
+          - most
+        default: strong
+      retry-run:
+        description: "Run id of an earlier revdep2 run; re-check only its not-ok packages"
+        type: string
+        default: ""
+      shard-budget-minutes:
+        description: "Check-time target per shard; smaller buys wall clock with more shards"
+        type: string
+        default: ""
+      max-parallel:
+        description: "Shards to run concurrently"
+        type: string
+        default: ""
+      refresh-baseline:
+        description: "Re-check the CRAN version even where a baseline is reusable"
+        type: boolean
+        default: false
+      baseline-max-age-days:
+        description: "Oldest baseline result worth reusing"
+        type: string
+        default: ""
+      fail-on:
+        description: "When the collect job turns the run red"
+        type: choice
+        options:
+          - newly-broken
+          - any
+          - none
+        default: newly-broken
+
+name: revdep2
+
+# One planning pass per branch at a time; a queued run waits rather than
+# killing shards mid-check, because a killed shard's unfinished packages would
+# have to be re-planned and re-checked.
+concurrency:
+  group: revdep2-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REVDEP2_PACKAGES: ${{ inputs.packages || '' }}
+  REVDEP2_WHICH: ${{ inputs.which || 'strong' }}
+  REVDEP2_RETRY_RUN: ${{ inputs.retry-run || '' }}
+  REVDEP2_SHARD_BUDGET_MINUTES: ${{ inputs.shard-budget-minutes || vars.REVDEP2_SHARD_BUDGET_MINUTES || '45' }}
+  REVDEP2_MAX_PARALLEL: ${{ inputs.max-parallel || vars.REVDEP2_MAX_PARALLEL || '20' }}
+  REVDEP2_REFRESH_BASELINE: ${{ inputs.refresh-baseline && '1' || '' }}
+  REVDEP2_BASELINE_MAX_AGE_DAYS: ${{ inputs.baseline-max-age-days || vars.REVDEP2_BASELINE_MAX_AGE_DAYS || '30' }}
+  REVDEP2_CHECK_TIMEOUT_MINUTES: ${{ vars.REVDEP2_CHECK_TIMEOUT_MINUTES || '30' }}
+  REVDEP2_DEADLINE_MINUTES: ${{ vars.REVDEP2_DEADLINE_MINUTES || '300' }}
+  REVDEP2_FAIL_ON: ${{ inputs.fail-on || 'newly-broken' }}
+
+jobs:
+  plan:
+    runs-on: ubuntu-26.04
+
+    name: "Plan revdep shards"
+
+    outputs:
+      # Fallbacks cover a planning step that did not run at all: `test` is
+      # guarded by `shards != '0'`, but its `strategy` must still parse.
+      matrix: ${{ steps.plan.outputs.matrix || '{"shard":["none"]}' }}
+      shards: ${{ steps.plan.outputs.shards || '0' }}
+      packages: ${{ steps.plan.outputs.packages || '0' }}
+      max_parallel: ${{ steps.plan.outputs.max_parallel || '1' }}
+      baseline_run: ${{ steps.plan.outputs.baseline_run || '0' }}
+      plan_hash: ${{ steps.plan.outputs.plan_hash || 'none' }}
+
+    permissions:
+      contents: read
+      actions: read
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install jsonlite
+        run: |
+          install.packages("jsonlite")
+        shell: Rscript {0}
+
+      - id: plan
+        name: Plan shards
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OUT: ${{ runner.temp }}/plan.json
+        run: |
+          Rscript ./.github/workflows/revdep2/plan.R
+        shell: bash
+
+      - uses: actions/upload-artifact@v5
+        if: steps.plan.outputs.shards != '0'
+        with:
+          name: revdep2-plan
+          path: ${{ runner.temp }}/plan.json
+          retention-days: 30
+          overwrite: true
+
+  build:
+    needs:
+      - plan
+
+    if: needs.plan.outputs.shards != '0'
+
+    runs-on: ubuntu-26.04
+
+    name: "Build binary, preflight dependencies"
+
+    permissions:
+      contents: read
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Begin custom: before install
+      # End custom: before install
+
+      - uses: ./.github/workflows/install
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cache-version: revdep2-1
+          needs: build
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: revdep2-plan
+          path: ${{ runner.temp }}/plan
+
+      # The preflight downloads every dependency binary once; saving the pak
+      # cache under the plan's hash hands the shards a warm start.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/R/pkgcache
+          key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
+          restore-keys: |
+            revdep2-pak-
+
+      - name: Build binary and preflight dependencies
+        env:
+          PLAN: ${{ runner.temp }}/plan/plan.json
+          OUT_DIR: ${{ runner.temp }}/pkg
+          PKG_SYSREQS: true
+        run: |
+          Rscript ./.github/workflows/revdep2/build.R
+        shell: bash
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: revdep2-pkg
+          path: ${{ runner.temp }}/pkg
+          retention-days: 30
+          overwrite: true
+
+  test:
+    needs:
+      - plan
+      - build
+
+    if: needs.plan.outputs.shards != '0'
+
+    runs-on: ubuntu-26.04
+
+    # Below GitHub's 6 h ceiling, and above the shard's own deadline: the shard
+    # is meant to stop itself and defer what is left, not to be killed
+    # mid-check.
+    timeout-minutes: 350
+
+    name: "shard ${{ matrix.shard }} (${{ matrix.label }})"
+
+    permissions:
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(needs.plan.outputs.max_parallel) }}
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      # prevent rgl issues because no X11 display is available
+      RGL_USE_NULL: true
+      # CRAN-like check conditions for the revdeps, not the incoming gauntlet
+      _R_CHECK_CRAN_INCOMING_: false
+      _R_CHECK_SYSTEM_CLOCK_: false
+      _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false
+      _R_CHECK_FORCE_SUGGESTS_: false
+      # Begin custom: env vars
+      # End custom: env vars
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-tinytex@v2
+
+      - name: Install system tools for checking
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y qpdf ghostscript
+        shell: bash
+
+      - name: Install pak
+        run: |
+          install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
+          install.packages(c("jsonlite", "rcmdcheck"))
+        shell: Rscript {0}
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/R/pkgcache
+          key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
+          restore-keys: |
+            revdep2-pak-
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: revdep2-plan
+          path: ${{ runner.temp }}/plan
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: revdep2-pkg
+          path: ${{ runner.temp }}/pkg
+
+      # The baseline lives on an earlier run; absence is not an error, the
+      # shard just checks the CRAN version fresh.
+      - uses: actions/download-artifact@v6
+        if: needs.plan.outputs.baseline_run != '0'
+        continue-on-error: true
+        with:
+          name: revdep2-baseline
+          run-id: ${{ needs.plan.outputs.baseline_run }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/baseline
+
+      # Begin custom: after install
+      # End custom: after install
+
+      - name: Check the shard
+        env:
+          SHARD: ${{ matrix.shard }}
+          PLAN: ${{ runner.temp }}/plan/plan.json
+          PKG_DIR: ${{ runner.temp }}/pkg
+          BASELINE_DIR: ${{ runner.temp }}/baseline
+          OUT_DIR: ${{ runner.temp }}/results
+          CHECK_TIMEOUT_MINUTES: ${{ env.REVDEP2_CHECK_TIMEOUT_MINUTES }}
+          DEADLINE_MINUTES: ${{ env.REVDEP2_DEADLINE_MINUTES }}
+          PKG_SYSREQS: true
+        run: |
+          Rscript ./.github/workflows/revdep2/shard.R
+        shell: bash
+
+      # Named per attempt: a re-run of one shard must not overwrite the results
+      # the other shards uploaded in the first attempt; the collector reads
+      # every attempt and lets the later one win per package.
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: revdep2-results-${{ matrix.shard }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/results
+          if-no-files-found: ignore
+          retention-days: 30
+
+  collect:
+    needs:
+      - plan
+      - build
+      - test
+
+    # `always()` so a run with red shards still reports -- a broken revdep is
+    # the result this workflow exists to surface. Guarded on plan and build
+    # having succeeded, because without a plan or a binary there is nothing to
+    # collect.
+    if: always() && needs.plan.result == 'success' && needs.build.result == 'success' && needs.plan.outputs.shards != '0'
+
+    runs-on: ubuntu-26.04
+
+    name: "Collect results and report"
+
+    permissions:
+      contents: read
+      actions: read
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install pak and jsonlite
+        run: |
+          install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
+          install.packages("jsonlite")
+        shell: Rscript {0}
+
+      # The reports come out of revdepcheck itself; when this fails the
+      # collector still writes a manifest-derived summary.
+      - name: Install revdepcheck
+        continue-on-error: true
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pak::pkg_install("krlmlr/revdepcheck")
+        shell: Rscript {0}
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: revdep2-plan
+          path: ${{ runner.temp }}/plan
+
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: revdep2-results-*
+          path: ${{ runner.temp }}/results
+
+      - uses: actions/download-artifact@v6
+        if: env.REVDEP2_RETRY_RUN != ''
+        continue-on-error: true
+        with:
+          name: revdep2-report
+          run-id: ${{ env.REVDEP2_RETRY_RUN }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/retry-report
+
+      - name: Collect results
+        env:
+          PLAN: ${{ runner.temp }}/plan/plan.json
+          RESULTS_DIR: ${{ runner.temp }}/results
+          RETRY_DIR: ${{ runner.temp }}/retry-report
+          OUT_DIR: revdep
+          BASELINE_OUT: ${{ runner.temp }}/baseline
+          FAIL_ON: ${{ env.REVDEP2_FAIL_ON }}
+        run: |
+          Rscript ./.github/workflows/revdep2/collect.R
+        shell: bash
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: revdep2-report
+          path: revdep
+          retention-days: 90
+          overwrite: true
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: revdep2-baseline
+          path: ${{ runner.temp }}/baseline
+          retention-days: 90
+          overwrite: true

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -96,6 +96,12 @@ on:
 
 name: revdep2
 
+# Read-only by default; every job opts back into what it actually needs.
+# Note that for a pull request from a fork GitHub caps the token at read-only
+# regardless of what is requested here.
+permissions:
+  contents: read
+
 # One planning pass per checked ref at a time; a queued run waits rather than
 # killing shards mid-check, because a killed shard's unfinished packages would
 # have to be re-planned and re-checked.
@@ -137,6 +143,8 @@ jobs:
 
     permissions:
       contents: read
+      # To find the newest earlier run with a baseline artifact and read its
+      # manifest, and to read the retried run's report.
       actions: read
 
     # Begin custom: services
@@ -299,6 +307,7 @@ jobs:
 
     permissions:
       contents: read
+      # To download the baseline artifact, which lives on an earlier run.
       actions: read
 
     strategy:
@@ -422,6 +431,7 @@ jobs:
 
     permissions:
       contents: read
+      # To download the retried run's report artifact, which lives on that run.
       actions: read
 
     # Begin custom: services

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -147,9 +147,6 @@ jobs:
       # manifest, and to read the retried run's report.
       actions: read
 
-    # Begin custom: services
-    # End custom: services
-
     steps:
       - uses: actions/checkout@v6
         with:
@@ -194,16 +191,10 @@ jobs:
     permissions:
       contents: read
 
-    # Begin custom: services
-    # End custom: services
-
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      # Begin custom: before install
-      # End custom: before install
 
       - uses: ./.github/workflows/install
         with:
@@ -239,9 +230,6 @@ jobs:
 
     permissions:
       contents: read
-
-    # Begin custom: services
-    # End custom: services
 
     steps:
       - uses: actions/checkout@v6
@@ -324,11 +312,6 @@ jobs:
       _R_CHECK_SYSTEM_CLOCK_: false
       _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false
       _R_CHECK_FORCE_SUGGESTS_: false
-      # Begin custom: env vars
-      # End custom: env vars
-
-    # Begin custom: services
-    # End custom: services
 
     steps:
       - uses: actions/checkout@v6
@@ -383,9 +366,6 @@ jobs:
           github-token: ${{ github.token }}
           path: ${{ runner.temp }}/baseline
 
-      # Begin custom: after install
-      # End custom: after install
-
       - name: Check the shard
         env:
           SHARD: ${{ matrix.shard }}
@@ -433,9 +413,6 @@ jobs:
       contents: read
       # To download the retried run's report artifact, which lives on that run.
       actions: read
-
-    # Begin custom: services
-    # End custom: services
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -1,0 +1,252 @@
+# `revdep2` — sharded reverse-dependency checking
+
+`.github/workflows/revdep2.yaml` checks every CRAN reverse dependency of the
+package twice — once against the CRAN version, once against the checked-out
+dev version — and reports the difference,
+the way [revdepcheck](https://github.com/r-lib/revdepcheck) does,
+but spread over as many GitHub Actions jobs as the batch needs.
+The trade is deliberate:
+runner minutes are spent (duplicate setup, duplicate dependency installs)
+to buy wall clock,
+where the older `revdep.yaml` spends one job per package
+and `revdepcheck::revdep_check()` spends one machine for everything.
+
+## Topology
+
+```
+plan     (1 job, ~2 min)
+  ├─ enumerate revdeps, or take the retry/explicit list
+  ├─ weigh each by CRAN's own check time for it
+  ├─ resolve the baseline donor run, decide per package what is reusable
+  └─ partition into shards → plan.json (artifact) + matrix (job output)
+
+build    (1 job)
+  ├─ R CMD build + R CMD INSTALL --build   → revdep2-pkg artifact
+  └─ install + load *every* dependency any revdep needs
+       → depfail.json, warm pak cache (saved under the plan hash)
+
+test     (one job per shard, max-parallel throttled, fail-fast: false)
+  ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
+  ├─ phase old: reuse baselines, check the rest against the CRAN version
+  ├─ install the prebuilt dev binary
+  ├─ phase new: check everything again, compare per package
+  └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
+
+collect  (1 job, if: always() past plan/build)
+  ├─ merge all shard attempts (+ carried results of a retried run)
+  ├─ reports via revdepcheck: README.md, problems.md, failures.md, cran.md
+  ├─ manifest.json, job summary, red/green verdict per fail-on
+  └─ revdep2-report + revdep2-baseline artifacts
+```
+
+A failing check never fails a shard,
+and a failing shard never aborts the run:
+`fail-fast: false` isolates shard-level accidents,
+the shard driver records per-package failure as data,
+and the collector runs on `always()` past a successful plan and build.
+The one red job a broken revdep can produce is `collect`,
+under the `fail-on` input's rule.
+
+## Weighing and partitioning
+
+CRAN publishes per-package check times for each flavor;
+`tools::CRAN_check_results()` carries them as `T_total`.
+The planner takes the `r-release-linux-x86_64` flavor as the proxy
+for what a check costs here:
+one check ≈ `T_total`, a package without a reusable baseline pays two,
+plus a small fixed overhead.
+Packages CRAN has no timing for get the cohort median.
+
+The shard count is demand-driven:
+the smallest `K` whose average check load fits `shard-budget-minutes`
+(default 45), capped by the 250-leg matrix limit.
+A smaller budget buys wall clock with more shards;
+the per-shard setup (~6 min: R, pandoc, TinyTeX, dependency install)
+is the price of each extra shard.
+
+Assignment is greedy, in two phases:
+
+1. **Round-robin the heavyweights.**
+   The `K` heaviest packages are dealt one per shard,
+   so no two giants end up queued behind each other.
+2. **Marginal-cost placement for the rest.**
+   Every remaining package, heaviest first,
+   goes to the shard where
+   `load + weight + install_seconds × |dependencies the shard does not yet have|`
+   is smallest.
+   The install penalty (default 2.5 s per package, from a warm binary cache)
+   is what pulls packages with overlapping dependency trees together,
+   so a shard's install phase is amortised over packages that share it.
+
+### Why greedy, not an exact optimisation
+
+The exact problem is makespan minimisation with sequence-dependent setup
+costs — bin packing crossed with a coverage objective —
+which is NP-hard in both halves,
+and the classic greedy (LPT: longest processing time first)
+is already within 4/3 − 1/(3K) of the optimal makespan.
+The inputs do not deserve better:
+CRAN timings come from a different machine under different load,
+install costs are a scalar guess,
+and the actual runtime moves with cache hits and CRAN's own state.
+An ILP or local-search pass could shave minutes off the plan on paper
+and would still be wrong by more than that in practice —
+and it would need a solver in a job whose entire budget is two minutes.
+The greedy pass is O(n · K) with a bitmap per shard,
+runs in well under a second for thousands of revdeps,
+and its plans are inspectable
+(the plan job's summary prints per-shard estimates and contents).
+
+`each.yaml` in duckdb-r solves the mirror-image problem
+(contiguous slices of a commit history, reuse via ccache adjacency);
+its two-pass rebalancing exists because contiguity pins its cuts.
+Here nothing is contiguous — any package can sit anywhere —
+so the whole plan family collapses into the one greedy pass
+and the only dial left is the budget.
+
+## The CRAN baseline, and when it is reused
+
+The old-version check of a revdep does not involve the dev code at all:
+it is the CRAN version of this package, the revdep, and their dependencies.
+Its result therefore outlives the run that produced it,
+and re-checking it every run would double the bill for no information.
+
+The collector publishes every old-version result as `revdep2-baseline`
+(`baseline.json` plus one `old.rds` per package),
+and the planner reuses an entry only when *everything that shaped it*
+is unchanged:
+
+| Criterion | Compared |
+| --- | --- |
+| revdep version | baseline vs `available.packages()` now |
+| our CRAN version | baseline vs CRAN now |
+| R series | baseline vs the runner's `major.minor` |
+| dependency versions | md5 over the sorted `package version` lines of the revdep's whole install closure, from CRAN metadata |
+| age | `checked_at` within `baseline-max-age-days` (default 30) |
+
+The dependency fingerprint is the load-bearing one:
+a tidyverse point release changes the environment an old check ran in,
+and versions-of-us-and-them alone would happily reuse a result
+that release just invalidated.
+The age cap backstops what CRAN metadata cannot see —
+the runner image, system libraries, network state.
+Reuse does not refresh `checked_at`:
+a result ages from the day it actually ran.
+`refresh-baseline: true` ignores all of it for one run.
+
+Baselines are looked up newest-run-first across the workflow's history
+(any branch — the dev code plays no part in an old check),
+and a retried run's own report doubles as its donor.
+A missing, expired, or partially unusable baseline is never an error;
+the affected packages are simply checked fresh.
+
+## Results, artifacts, tooling
+
+Every artifact this workflow writes:
+
+| Artifact | Content | Lifetime |
+| --- | --- | --- |
+| `revdep2-plan` | `plan.json` | 30 days |
+| `revdep2-pkg` | source tarball, platform binary, `meta.json`, `depfail.json` | 30 days |
+| `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
+| `revdep2-report` | `README.md`, `problems.md`, `failures.md`, `cran.md`, `manifest.json`, all `pkgs/` | 90 days |
+| `revdep2-baseline` | `baseline.json`, `old-rds/<p>.rds` | 90 days |
+
+The reports are revdepcheck's own,
+generated through its `results` injection point
+(`cloud_report_summary()` and friends),
+so `README.md` reads exactly like a local `revdep_check()`'s.
+
+To fetch a run's results:
+
+```sh
+.github/workflows/revdep2/fetch.sh            # newest completed run
+.github/workflows/revdep2/fetch.sh <run-id>   # a specific one
+```
+
+To re-check only what a run could not declare ok —
+after fixing the code, after a flaky failure, after a deadline deferral:
+
+```sh
+gh workflow run revdep2.yaml -f retry-run=<run-id>
+```
+
+The retry's collector carries the donor run's untouched results over,
+so its report is complete again, not a fragment.
+
+## Failure modes
+
+| Situation | Outcome |
+| --- | --- |
+| A revdep breaks under the dev version | `newly_broken` in manifest and report; run red only per `fail-on` |
+| A revdep fails under both versions | `ok` (no *new* problems), visible in the report's tables |
+| A check times out | rcmdcheck kills it at `REVDEP2_CHECK_TIMEOUT_MINUTES`; compared as `t-`, reported `failed` |
+| A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
+| A dependency fails the build-job preflight | reported in the build summary and `depfail.json`; shards still try their own subset |
+| A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
+| A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
+| A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
+| The baseline artifact is gone | planner reuses nothing, everything checked fresh |
+| CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |
+| The package is not on CRAN | plan emits zero shards, run ends green |
+| `collect` finds new problems | uploads everything first, then exits per `fail-on` |
+
+## Knobs
+
+| Knob | Input | Variable | Default |
+| --- | --- | --- | --- |
+| Packages to check | `packages` | — | all revdeps |
+| Revdep set | `which` | — | `strong` |
+| Retry a run | `retry-run` | — | — |
+| Check-time target per shard | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
+| Concurrent shards | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
+| Ignore reusable baselines | `refresh-baseline` | — | false |
+| Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |
+| Per-check timeout | — | `REVDEP2_CHECK_TIMEOUT_MINUTES` | 30 |
+| Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
+| Red-run rule | `fail-on` | — | `newly-broken` |
+
+## Prior art
+
+Surveyed before building this; what each contributed:
+
+* [r-lib/revdepcheck](https://github.com/r-lib/revdepcheck) —
+  the comparison model (old vs new `rcmdcheck`, `compare_checks()`),
+  the report format, and the `results` injection point the collector uses.
+  Its `cloud_check()` (one AWS Batch job per package, fetch, compare locally)
+  is the closest architectural relative.
+* [r-devel/recheck](https://github.com/r-devel/recheck) —
+  CRAN-parity system libraries, binary-first dependency installs,
+  and the honest framing that revdep results are diagnostics,
+  too volatile for a pass/fail gate (hence `fail-on`).
+* [yihui/crandalf](https://github.com/yihui/crandalf) —
+  batching revdeps across CI jobs,
+  and re-checking only previously failed packages (`retry-run` here).
+* [HenrikBengtsson/revdepcheck.extras](https://github.com/HenrikBengtsson/revdepcheck.extras) —
+  pre-installing the dependency universe before the checks start
+  (the build job's preflight).
+* duckdb-r's `each.yaml` —
+  the plan/matrix/fan-in shape, cost-balanced shards under a budget,
+  graceful deadlines with deferral, per-attempt artifacts,
+  and empty-matrix/fallback-output hygiene.
+
+No published workflow was found that balances revdep shards
+by CRAN check timings or by dependency overlap;
+that part is new here.
+
+## Not yet validated
+
+1. The cost model's constants
+   (45 min budget, 6 min setup, 2.5 s per dependency install, 0.5 min
+   per-package overhead) are estimates, not fits.
+   Shard manifests record actual durations, so they can be fitted
+   from real runs the way duckdb-r recalibrated `each`.
+2. Bioconductor revdeps are out of scope:
+   enumeration, versions and fingerprints all come from CRAN metadata.
+3. The report generation leans on unexported revdepcheck internals
+   (`try_compare_checks()`, `rcmdcheck_error()`) via `:::`,
+   with a manifest-only fallback when they drift.
+4. Baselines live in artifacts, whose retention caps reuse at 90 days
+   and whose availability is per-repository;
+   an orphan branch (the `rcc` model) would be durable and fetchable
+   but grows the repository.

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -14,40 +14,57 @@ and `revdepcheck::revdep_check()` spends one machine for everything.
 ## Topology
 
 ```
-plan     (1 job, ~2 min)
-  ├─ enumerate revdeps, or take the retry/explicit list
-  ├─ weigh each by CRAN's own check time for it
-  ├─ resolve the baseline donor run, decide per package what is reusable
-  └─ partition into shards → plan.json (artifact) + matrix (job output)
+plan      (1 job, ~2 min)              build  (1 job, parallel to plan)
+  ├─ enumerate revdeps to `depth`,       └─ R CMD build
+  │    or take the retry/explicit list        + R CMD INSTALL --build
+  ├─ weigh each by CRAN's check time             → revdep2-pkg artifact
+  ├─ resolve the baseline donor run,
+  │    decide per package what is reusable
+  └─ partition into shards
+       → plan.json (artifact) + matrix (job output)
 
-build    (1 job)
-  ├─ R CMD build + R CMD INSTALL --build   → revdep2-pkg artifact
+preflight (1 job; a dry run stops before it)
   └─ install + load *every* dependency any revdep needs
        → depfail.json, warm pak cache (saved under the plan hash)
 
-test     (one job per shard, max-parallel throttled, fail-fast: false)
+test      (one job per shard, max-parallel throttled, fail-fast: false)
   ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
   ├─ phase old: reuse baselines, check the rest against the CRAN version
   ├─ install the prebuilt dev binary
   ├─ phase new: check everything again, compare per package
   └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
 
-collect  (1 job, if: always() past plan/build)
+collect   (1 job, if: always() past plan/build/preflight)
   ├─ merge all shard attempts (+ carried results of a retried run)
   ├─ reports via revdepcheck: README.md, problems.md, failures.md, cran.md
-  ├─ manifest.json, job summary, red/green verdict per fail-on
-  └─ revdep2-report + revdep2-baseline artifacts
+  └─ manifest.json, job summary, revdep2-report + revdep2-baseline artifacts
 ```
 
-A failing check never fails a shard,
-and a failing shard never aborts the run:
+The workflow is dispatch-only — nothing runs on push —
+and `dry-run: true` stops after planning,
+which is how a plan is inspected for free.
+The `ref` input checks any branch, tag or commit SHA:
+the dispatch itself can only target a branch or tag,
+so arbitrary SHAs travel through the input,
+with the one constraint that the tree must contain these scripts.
+
+A failing check never fails anything:
 `fail-fast: false` isolates shard-level accidents,
 the shard driver records per-package failure as data,
-and the collector runs on `always()` past a successful plan and build.
-The one red job a broken revdep can produce is `collect`,
-under the `fail-on` input's rule.
+the collector runs on `always()` past its prerequisites,
+and check results never turn the run red —
+the job summary and the `revdep2-report` artifact are the deliverable.
+A red job means broken infrastructure, not a broken revdep.
 
 ## Weighing and partitioning
+
+Enumeration is breadth-first to `depth`:
+level 1 depends on the package directly,
+level 2 on a level-1 package, and so on,
+up to the fixpoint for `depth: all`.
+Deeper levels break through their intermediaries,
+so their CRAN-vs-dev comparison stays meaningful,
+and their install closures pull the intermediaries in automatically.
 
 CRAN publishes per-package check times for each flavor;
 `tools::CRAN_check_results()` carries them as `T_total`.
@@ -56,6 +73,10 @@ for what a check costs here:
 one check ≈ `T_total`, a package without a reusable baseline pays two,
 plus a small fixed overhead.
 Packages CRAN has no timing for get the cohort median.
+The same number sizes the per-check timeout:
+`max(REVDEP2_TIMEOUT_MIN_MINUTES, REVDEP2_TIMEOUT_FACTOR × T_total)`,
+so a package gets killed relative to what it normally costs,
+with the floor covering the gap between CRAN's machines and these runners.
 
 The shard count is demand-driven:
 the smallest `K` whose average check load fits `shard-budget-minutes`
@@ -147,7 +168,8 @@ Every artifact this workflow writes:
 | Artifact | Content | Lifetime |
 | --- | --- | --- |
 | `revdep2-plan` | `plan.json` | 30 days |
-| `revdep2-pkg` | source tarball, platform binary, `meta.json`, `depfail.json` | 30 days |
+| `revdep2-pkg` | source tarball, platform binary, `meta.json` | 30 days |
+| `revdep2-preflight` | `depfail.json` | 30 days |
 | `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
 | `revdep2-report` | `README.md`, `problems.md`, `failures.md`, `cran.md`, `manifest.json`, all `pkgs/` | 90 days |
 | `revdep2-baseline` | `baseline.json`, `old-rds/<p>.rds` | 90 days |
@@ -178,33 +200,36 @@ so its report is complete again, not a fragment.
 
 | Situation | Outcome |
 | --- | --- |
-| A revdep breaks under the dev version | `newly_broken` in manifest and report; run red only per `fail-on` |
+| A revdep breaks under the dev version | `newly_broken` in manifest and report; the run stays green |
 | A revdep fails under both versions | `ok` (no *new* problems), visible in the report's tables |
-| A check times out | rcmdcheck kills it at `REVDEP2_CHECK_TIMEOUT_MINUTES`; compared as `t-`, reported `failed` |
+| A check times out | rcmdcheck kills it at `max(floor, factor × its CRAN time)`; compared as `t-`, reported `failed` |
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
-| A dependency fails the build-job preflight | reported in the build summary and `depfail.json`; shards still try their own subset |
+| A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
 | A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
 | The baseline artifact is gone | planner reuses nothing, everything checked fresh |
 | CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |
 | The package is not on CRAN | plan emits zero shards, run ends green |
-| `collect` finds new problems | uploads everything first, then exits per `fail-on` |
+| `collect` finds new problems | reported in the summary and the report artifact; the run stays green |
 
 ## Knobs
 
 | Knob | Input | Variable | Default |
 | --- | --- | --- | --- |
+| Ref to check (branch, tag, SHA) | `ref` | — | the dispatched ref |
 | Packages to check | `packages` | — | all revdeps |
 | Revdep set | `which` | — | `strong` |
+| Revdep depth (`1`, `2`, …, `all`) | `depth` | — | 1 |
 | Retry a run | `retry-run` | — | — |
+| Plan only | `dry-run` | — | false |
 | Check-time target per shard | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
 | Concurrent shards | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
 | Ignore reusable baselines | `refresh-baseline` | — | false |
 | Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |
-| Per-check timeout | — | `REVDEP2_CHECK_TIMEOUT_MINUTES` | 30 |
+| Per-check timeout factor | — | `REVDEP2_TIMEOUT_FACTOR` | 1.5 × CRAN time |
+| Per-check timeout floor | — | `REVDEP2_TIMEOUT_MIN_MINUTES` | 10 |
 | Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
-| Red-run rule | `fail-on` | — | `newly-broken` |
 
 ## Prior art
 
@@ -218,13 +243,13 @@ Surveyed before building this; what each contributed:
 * [r-devel/recheck](https://github.com/r-devel/recheck) —
   CRAN-parity system libraries, binary-first dependency installs,
   and the honest framing that revdep results are diagnostics,
-  too volatile for a pass/fail gate (hence `fail-on`).
+  too volatile for a pass/fail gate (hence check results never fail the run).
 * [yihui/crandalf](https://github.com/yihui/crandalf) —
   batching revdeps across CI jobs,
   and re-checking only previously failed packages (`retry-run` here).
 * [HenrikBengtsson/revdepcheck.extras](https://github.com/HenrikBengtsson/revdepcheck.extras) —
   pre-installing the dependency universe before the checks start
-  (the build job's preflight).
+  (the preflight job).
 * duckdb-r's `each.yaml` —
   the plan/matrix/fan-in shape, cost-balanced shards under a budget,
   graceful deadlines with deferral, per-attempt artifacts,

--- a/.github/workflows/revdep2/build.R
+++ b/.github/workflows/revdep2/build.R
@@ -1,0 +1,193 @@
+# Build the package under test once, and prove the dependency world installs.
+#
+# Two deliverables, both consumed by every shard:
+#
+#   1. A source tarball and a platform binary of the checked-out (dev) package,
+#      so no shard pays the compilation twice. Shards install the binary; the
+#      tarball is kept alongside for reference and local reproduction.
+#   2. A warmed pak package cache: this job installs the union of every
+#      dependency any revdep needs into a scratch library -- which downloads
+#      every binary exactly once into the cache that the workflow then saves
+#      for the shards -- and then load-tests each installed package. Broken or
+#      uninstallable dependencies surface here, before any shard has spent a
+#      minute on checks, and are reported in depfail.json and the job summary.
+#
+# A dependency failure is a report, not a stop: shards attempt their own subset
+# regardless (their PPM snapshot may succeed where this one failed), and a
+# revdep whose dependencies genuinely cannot be installed fails its own check
+# with an install log, which is the result a report can work with.
+#
+# Environment variables:
+#   PLAN     - plan.json from plan.R (default: plan.json)
+#   OUT_DIR  - where the tarball, binary, metadata and depfail report land
+#              (default: pkg)
+
+source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+
+plan_path <- env_chr("PLAN", "plan.json")
+out_dir <- env_chr("OUT_DIR", "pkg")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+
+plan <- read_json(plan_path)
+package <- plan$package
+install_union <- unlist(plan$install_union, use.names = FALSE)
+
+# ------------------------------------------------------------------- build ---
+
+inform("Building ", package, " ", plan$dev_version)
+status <- system2("R", c("CMD", "build", "--no-manual", "."))
+if (status != 0) {
+  stop("R CMD build failed", call. = FALSE)
+}
+tarball <- sort(
+  list.files(pattern = sprintf("^%s_.*[.]tar[.]gz$", package)),
+  decreasing = TRUE
+)[[1]]
+
+inform("Building the binary from ", tarball)
+binary_dir <- file.path(out_dir, "bin")
+dir.create(binary_dir, recursive = TRUE, showWarnings = FALSE)
+build_lib <- tempfile("lib-")
+dir.create(build_lib)
+status <- system2(
+  "R",
+  c("CMD", "INSTALL", "--build", "-l", build_lib, tarball)
+)
+if (status != 0) {
+  stop("R CMD INSTALL --build failed", call. = FALSE)
+}
+binary <- sort(
+  list.files(pattern = sprintf("^%s_.*_R_.*[.]tar[.]gz$", package)),
+  decreasing = TRUE
+)[[1]]
+file.rename(binary, file.path(binary_dir, binary))
+file.copy(tarball, file.path(out_dir, tarball))
+
+write_json(
+  list(
+    package = package,
+    dev_version = plan$dev_version,
+    cran_version = plan$cran_version,
+    sha = plan$sha,
+    r_version = plan$r_version,
+    platform = R.version$platform,
+    tarball = tarball,
+    binary = file.path("bin", binary),
+    built_at = now_utc()
+  ),
+  file.path(out_dir, "meta.json")
+)
+inform("Binary: ", binary)
+
+# --------------------------------------------------------------- preflight ---
+
+lib <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-preflight-lib")
+dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+failures <- list()
+
+inform("Preflight: installing ", length(install_union), " packages")
+installed_ok <- tryCatch(
+  {
+    pak::pkg_install(install_union, lib = lib, ask = FALSE)
+    TRUE
+  },
+  error = function(e) {
+    inform("Bulk install failed: ", conditionMessage(e))
+    FALSE
+  }
+)
+if (!installed_ok) {
+  # One bad package must not hide the state of the other thousand: retry each
+  # missing package on its own and record exactly which ones will not install.
+  for (p in install_union) {
+    if (dir.exists(file.path(lib, p))) {
+      next
+    }
+    result <- tryCatch(
+      {
+        pak::pkg_install(p, lib = lib, ask = FALSE)
+        NULL
+      },
+      error = function(e) conditionMessage(e)
+    )
+    if (!is.null(result)) {
+      failures[[length(failures) + 1]] <- list(
+        package = p,
+        phase = "install",
+        message = result
+      )
+    }
+  }
+}
+
+# Load every installed dependency, in chunks small enough to stay clear of the
+# DLL limit; a failing chunk is retried one package at a time so a single bad
+# namespace names itself.
+installed <- intersect(install_union, rownames(utils::installed.packages(lib)))
+inform("Preflight: loading ", length(installed), " packages")
+load_batch <- function(pkgs) {
+  script <- tempfile(fileext = ".R")
+  writeLines(
+    c(
+      sprintf(".libPaths(c(%s, .libPaths()))", deparse(lib)),
+      "for (p in commandArgs(trailingOnly = TRUE)) {",
+      "  loadNamespace(p)",
+      "  writeLines(paste0('LOADED ', p))",
+      "}"
+    ),
+    script
+  )
+  out <- suppressWarnings(system2(
+    "Rscript",
+    c("--vanilla", script, pkgs),
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+  loaded <- sub("^LOADED ", "", grep("^LOADED ", out, value = TRUE))
+  list(failed = setdiff(pkgs, loaded), log = out)
+}
+chunks <- split(installed, ceiling(seq_along(installed) / 40))
+for (chunk in chunks) {
+  first <- load_batch(chunk)
+  if (length(first$failed) == 0) {
+    next
+  }
+  for (p in first$failed) {
+    single <- load_batch(p)
+    if (length(single$failed) > 0) {
+      failures[[length(failures) + 1]] <- list(
+        package = p,
+        phase = "load",
+        message = paste(utils::tail(sanitize_log(single$log), 20), collapse = "\n")
+      )
+    }
+  }
+}
+
+write_json(failures, file.path(out_dir, "depfail.json"))
+
+# ------------------------------------------------------------------ summary --
+
+append_summary(c(
+  "## revdep2 build",
+  "",
+  sprintf(
+    "Built `%s` %s (binary `%s`), preflighted %d dependencies: %d could not be installed or loaded.",
+    package, plan$dev_version, binary, length(install_union), length(failures)
+  ),
+  ""
+))
+if (length(failures) > 0) {
+  df <- data.frame(
+    Package = vapply(failures, function(f) f$package, character(1)),
+    Phase = vapply(failures, function(f) f$phase, character(1))
+  )
+  append_summary(md_table(df))
+  for (f in failures) {
+    append_summary(md_details(
+      sprintf("<code>%s</code> &mdash; %s failure", f$package, f$phase),
+      strsplit(f$message, "\n")[[1]]
+    ))
+  }
+  inform(length(failures), " dependencies failed preflight; see depfail.json")
+}

--- a/.github/workflows/revdep2/build.R
+++ b/.github/workflows/revdep2/build.R
@@ -1,40 +1,31 @@
-# Build the package under test once, and prove the dependency world installs.
+# Build the package under test once: a source tarball and a platform binary,
+# so no shard pays the compilation twice. Shards install the binary; the
+# tarball is kept alongside for reference and local reproduction.
 #
-# Two deliverables, both consumed by every shard:
-#
-#   1. A source tarball and a platform binary of the checked-out (dev) package,
-#      so no shard pays the compilation twice. Shards install the binary; the
-#      tarball is kept alongside for reference and local reproduction.
-#   2. A warmed pak package cache: this job installs the union of every
-#      dependency any revdep needs into a scratch library -- which downloads
-#      every binary exactly once into the cache that the workflow then saves
-#      for the shards -- and then load-tests each installed package. Broken or
-#      uninstallable dependencies surface here, before any shard has spent a
-#      minute on checks, and are reported in depfail.json and the job summary.
-#
-# A dependency failure is a report, not a stop: shards attempt their own subset
-# regardless (their PPM snapshot may succeed where this one failed), and a
-# revdep whose dependencies genuinely cannot be installed fails its own check
-# with an install log, which is the result a report can work with.
+# Deliberately independent of the plan, so the job can run in parallel with
+# planning; everything it needs is the checkout.
 #
 # Environment variables:
-#   PLAN     - plan.json from plan.R (default: plan.json)
-#   OUT_DIR  - where the tarball, binary, metadata and depfail report land
-#              (default: pkg)
+#   OUT_DIR  - where the tarball, binary and metadata land (default: pkg)
 
 source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
 
-plan_path <- env_chr("PLAN", "plan.json")
 out_dir <- env_chr("OUT_DIR", "pkg")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
-plan <- read_json(plan_path)
-package <- plan$package
-install_union <- unlist(plan$install_union, use.names = FALSE)
+desc <- read.dcf("DESCRIPTION")[1, ]
+package <- unname(desc[["Package"]])
+dev_version <- unname(desc[["Version"]])
 
-# ------------------------------------------------------------------- build ---
+head_sha <- tryCatch(
+  system2("git", c("rev-parse", "HEAD"), stdout = TRUE, stderr = NULL)[[1]],
+  error = function(e) ""
+)
+if (!nzchar(head_sha)) {
+  head_sha <- env_chr("GITHUB_SHA")
+}
 
-inform("Building ", package, " ", plan$dev_version)
+inform("Building ", package, " ", dev_version)
 status <- system2("R", c("CMD", "build", "--no-manual", "."))
 if (status != 0) {
   stop("R CMD build failed", call. = FALSE)
@@ -66,10 +57,9 @@ file.copy(tarball, file.path(out_dir, tarball))
 write_json(
   list(
     package = package,
-    dev_version = plan$dev_version,
-    cran_version = plan$cran_version,
-    sha = plan$sha,
-    r_version = plan$r_version,
+    dev_version = dev_version,
+    sha = head_sha,
+    r_version = paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = "."),
     platform = R.version$platform,
     tarball = tarball,
     binary = file.path("bin", binary),
@@ -79,115 +69,8 @@ write_json(
 )
 inform("Binary: ", binary)
 
-# --------------------------------------------------------------- preflight ---
-
-lib <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-preflight-lib")
-dir.create(lib, recursive = TRUE, showWarnings = FALSE)
-failures <- list()
-
-inform("Preflight: installing ", length(install_union), " packages")
-installed_ok <- tryCatch(
-  {
-    pak::pkg_install(install_union, lib = lib, ask = FALSE)
-    TRUE
-  },
-  error = function(e) {
-    inform("Bulk install failed: ", conditionMessage(e))
-    FALSE
-  }
-)
-if (!installed_ok) {
-  # One bad package must not hide the state of the other thousand: retry each
-  # missing package on its own and record exactly which ones will not install.
-  for (p in install_union) {
-    if (dir.exists(file.path(lib, p))) {
-      next
-    }
-    result <- tryCatch(
-      {
-        pak::pkg_install(p, lib = lib, ask = FALSE)
-        NULL
-      },
-      error = function(e) conditionMessage(e)
-    )
-    if (!is.null(result)) {
-      failures[[length(failures) + 1]] <- list(
-        package = p,
-        phase = "install",
-        message = result
-      )
-    }
-  }
-}
-
-# Load every installed dependency, in chunks small enough to stay clear of the
-# DLL limit; a failing chunk is retried one package at a time so a single bad
-# namespace names itself.
-installed <- intersect(install_union, rownames(utils::installed.packages(lib)))
-inform("Preflight: loading ", length(installed), " packages")
-load_batch <- function(pkgs) {
-  script <- tempfile(fileext = ".R")
-  writeLines(
-    c(
-      sprintf(".libPaths(c(%s, .libPaths()))", deparse(lib)),
-      "for (p in commandArgs(trailingOnly = TRUE)) {",
-      "  loadNamespace(p)",
-      "  writeLines(paste0('LOADED ', p))",
-      "}"
-    ),
-    script
-  )
-  out <- suppressWarnings(system2(
-    "Rscript",
-    c("--vanilla", script, pkgs),
-    stdout = TRUE,
-    stderr = TRUE
-  ))
-  loaded <- sub("^LOADED ", "", grep("^LOADED ", out, value = TRUE))
-  list(failed = setdiff(pkgs, loaded), log = out)
-}
-chunks <- split(installed, ceiling(seq_along(installed) / 40))
-for (chunk in chunks) {
-  first <- load_batch(chunk)
-  if (length(first$failed) == 0) {
-    next
-  }
-  for (p in first$failed) {
-    single <- load_batch(p)
-    if (length(single$failed) > 0) {
-      failures[[length(failures) + 1]] <- list(
-        package = p,
-        phase = "load",
-        message = paste(utils::tail(sanitize_log(single$log), 20), collapse = "\n")
-      )
-    }
-  }
-}
-
-write_json(failures, file.path(out_dir, "depfail.json"))
-
-# ------------------------------------------------------------------ summary --
-
 append_summary(c(
   "## revdep2 build",
   "",
-  sprintf(
-    "Built `%s` %s (binary `%s`), preflighted %d dependencies: %d could not be installed or loaded.",
-    package, plan$dev_version, binary, length(install_union), length(failures)
-  ),
-  ""
+  sprintf("Built `%s` %s: `%s`.", package, dev_version, binary)
 ))
-if (length(failures) > 0) {
-  df <- data.frame(
-    Package = vapply(failures, function(f) f$package, character(1)),
-    Phase = vapply(failures, function(f) f$phase, character(1))
-  )
-  append_summary(md_table(df))
-  for (f in failures) {
-    append_summary(md_details(
-      sprintf("<code>%s</code> &mdash; %s failure", f$package, f$phase),
-      strsplit(f$message, "\n")[[1]]
-    ))
-  }
-  inform(length(failures), " dependencies failed preflight; see depfail.json")
-}

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -23,8 +23,9 @@
 #   RETRY_DIR    - the revdep2-report artifact of the run being retried, if any
 #   OUT_DIR      - report directory (default: revdep)
 #   BASELINE_OUT - baseline directory (default: baseline)
-#   FAIL_ON      - "newly-broken" (default), "any", or "none": when this script
-#                  exits non-zero
+#
+# Always exits zero: check results are the report's business, not the job
+# status's -- only a genuinely broken collector fails this job.
 
 source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
 
@@ -34,7 +35,6 @@ plan <- read_json(env_chr("PLAN", "plan.json"))
 retry_dir <- env_chr("RETRY_DIR")
 out_dir <- env_chr("OUT_DIR", "revdep")
 baseline_out <- env_chr("BASELINE_OUT", "baseline")
-fail_on <- match.arg(env_chr("FAIL_ON", "newly-broken"), c("newly-broken", "any", "none"))
 
 dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
 dir.create(file.path(baseline_out, "old-rds"), recursive = TRUE, showWarnings = FALSE)
@@ -267,15 +267,8 @@ append_summary(c(
   "```"
 ))
 
-verdict_bad <- switch(
-  fail_on,
-  "none" = character(),
-  "newly-broken" = "newly_broken",
-  "any" = c("newly_broken", "failed", "depfail", "error", "deferred")
+not_ok <- sum(results_tbl != "ok")
+inform(
+  length(entries), " package(s): ", sum(results_tbl == "ok"), " ok, ",
+  not_ok, " with findings -- see the summary and the revdep2-report artifact"
 )
-bad <- sum(results_tbl %in% verdict_bad)
-if (bad > 0) {
-  inform(bad, " package(s) fail the run under fail-on=", fail_on)
-  quit(save = "no", status = 1)
-}
-inform("All well under fail-on=", fail_on)

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -1,0 +1,281 @@
+# Fan-in for revdep2: merge every shard's results into one report, one
+# manifest, and one baseline for future runs to reuse.
+#
+# Reads all revdep2-results-* artifacts (every attempt; on a re-run the later
+# attempt wins per package), folds in the untouched results of the run being
+# retried so the report is always complete, and writes:
+#
+#   revdep/README.md     summary, revdepcheck-style
+#   revdep/problems.md   details for packages with new problems
+#   revdep/failures.md   details for packages that could not be checked
+#   revdep/cran.md       the paragraph for cran-comments.md
+#   revdep/manifest.json one entry per package, machine-readable
+#   revdep/pkgs/<p>/     old.rds, new.rds, kept new-version check output
+#
+# plus the baseline artifact content (baseline.json, old-rds/<p>.rds): every
+# reusable old-version result of this run, stamped with the metadata the next
+# plan compares against -- versions, R series, dependency fingerprint, and the
+# date the old check *actually* ran (reuse does not refresh it).
+#
+# Environment variables:
+#   RESULTS_DIR  - directory the shard artifacts were downloaded into (required)
+#   PLAN         - plan.json (default: plan.json)
+#   RETRY_DIR    - the revdep2-report artifact of the run being retried, if any
+#   OUT_DIR      - report directory (default: revdep)
+#   BASELINE_OUT - baseline directory (default: baseline)
+#   FAIL_ON      - "newly-broken" (default), "any", or "none": when this script
+#                  exits non-zero
+
+source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+
+results_dir <- env_chr("RESULTS_DIR")
+stopifnot(nzchar(results_dir))
+plan <- read_json(env_chr("PLAN", "plan.json"))
+retry_dir <- env_chr("RETRY_DIR")
+out_dir <- env_chr("OUT_DIR", "revdep")
+baseline_out <- env_chr("BASELINE_OUT", "baseline")
+fail_on <- match.arg(env_chr("FAIL_ON", "newly-broken"), c("newly-broken", "any", "none"))
+
+dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
+dir.create(file.path(baseline_out, "old-rds"), recursive = TRUE, showWarnings = FALSE)
+
+# ------------------------------------------------------------------- merge ---
+
+# Shard artifacts are named revdep2-results-<shard>-<attempt>; walking them in
+# attempt order makes the later attempt win when a shard was re-run.
+attempt_of <- function(path) {
+  n <- suppressWarnings(as.integer(sub("^.*-", "", basename(path))))
+  if (is.na(n)) 0L else n
+}
+shard_dirs <- list.dirs(results_dir, recursive = FALSE)
+shard_dirs <- shard_dirs[order(vapply(shard_dirs, attempt_of, integer(1)))]
+
+entries <- list()
+take <- function(entry, from) {
+  entry$carried <- isTRUE(entry$carried)
+  entries[[entry$package]] <<- entry
+  src <- file.path(from, "pkgs", entry$package)
+  if (dir.exists(src)) {
+    dest <- file.path(out_dir, "pkgs", entry$package)
+    unlink(dest, recursive = TRUE)
+    dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+    file.copy(list.files(src, full.names = TRUE), dest, recursive = TRUE)
+  }
+}
+
+for (dir in shard_dirs) {
+  manifest <- file.path(dir, "manifest.ndjson")
+  if (!file.exists(manifest)) {
+    next
+  }
+  for (line in readLines(manifest, warn = FALSE)) {
+    if (nzchar(trimws(line))) {
+      take(jsonlite::fromJSON(line, simplifyVector = FALSE), dir)
+    }
+  }
+}
+inform("Collected ", length(entries), " package(s) from ", length(shard_dirs), " shard artifact(s)")
+
+# A retried run reports the whole picture: results the retry did not touch are
+# carried over from the earlier run's report, marked as such.
+if (nzchar(retry_dir) && file.exists(file.path(retry_dir, "manifest.json"))) {
+  carried <- 0L
+  for (entry in read_json(file.path(retry_dir, "manifest.json"))) {
+    if (is.null(entries[[entry$package]])) {
+      entry$carried <- TRUE
+      take(entry, retry_dir)
+      carried <- carried + 1L
+    }
+  }
+  inform("Carried ", carried, " untouched result(s) over from run ", plan$retry_of)
+}
+
+entries <- entries[order(names(entries))]
+results_tbl <- vapply(entries, function(e) e$result, character(1))
+
+# ---------------------------------------------------------------- manifest ---
+
+write_json(
+  list(
+    package = plan$package,
+    dev_version = plan$dev_version,
+    cran_version = plan$cran_version,
+    r_version = plan$r_version,
+    sha = plan$sha,
+    run_id = env_chr("GITHUB_RUN_ID"),
+    retry_of = plan$retry_of,
+    generated_at = now_utc()
+  ),
+  file.path(out_dir, "run.json")
+)
+write_json(unname(entries), file.path(out_dir, "manifest.json"))
+
+# ---------------------------------------------------------------- baseline ---
+
+baseline <- list()
+for (entry in entries) {
+  rds <- file.path(out_dir, "pkgs", entry$package, "old.rds")
+  if (!file.exists(rds) || is.null(entry$old_checked_at) || is.na(entry$old_checked_at)) {
+    next
+  }
+  file.copy(rds, file.path(baseline_out, "old-rds", paste0(entry$package, ".rds")))
+  baseline[[length(baseline) + 1]] <- list(
+    package = entry$package,
+    version = entry$version,
+    our_cran_version = entry$our_cran_version,
+    r_version = plan$r_version,
+    dep_fingerprint = entry$dep_fingerprint,
+    checked_at = entry$old_checked_at,
+    status_old = entry$status_old,
+    has_old = TRUE
+  )
+}
+write_json(baseline, file.path(baseline_out, "baseline.json"))
+inform("Baseline carries ", length(baseline), " old-version result(s)")
+
+# ----------------------------------------------------------------- reports ---
+
+# The report machinery is revdepcheck's own, fed through its `results`
+# injection point; when the package is unavailable the manifest-derived
+# summary below still stands on its own.
+has_revdepcheck <- requireNamespace("revdepcheck", quietly = TRUE)
+
+comparison_of <- function(entry) {
+  dir <- file.path(out_dir, "pkgs", entry$package)
+  old_path <- file.path(dir, "old.rds")
+  new_path <- file.path(dir, "new.rds")
+  shim <- function(message) {
+    res <- revdepcheck:::rcmdcheck_error(
+      entry$package,
+      old = list(stdout = message, stderr = ""),
+      new = list(stdout = message, stderr = "")
+    )
+    res$version <- entry$version
+    res
+  }
+  if (!file.exists(old_path) || !file.exists(new_path)) {
+    message <- if (nzchar(entry$message %||% "")) {
+      entry$message
+    } else {
+      sprintf("Not checked (%s)", entry$result)
+    }
+    return(shim(message))
+  }
+  tryCatch(
+    revdepcheck:::try_compare_checks(
+      entry$package,
+      readRDS(old_path),
+      readRDS(new_path)
+    ),
+    error = function(e) shim(conditionMessage(e))
+  )
+}
+
+preamble <- c(
+  "# Platform",
+  "",
+  md_table(data.frame(
+    field = c("package", "dev", "CRAN", "commit", "R", "platform", "run", "date"),
+    value = c(
+      plan$package,
+      plan$dev_version,
+      plan$cran_version,
+      substr(plan$sha, 1, 9),
+      plan$r_version,
+      R.version$platform,
+      env_chr("GITHUB_RUN_ID", "local"),
+      format(Sys.Date())
+    )
+  )),
+  ""
+)
+
+if (has_revdepcheck) {
+  results <- lapply(unname(entries), comparison_of)
+  names(results) <- names(entries)
+
+  capture_report <- function(fun, ...) {
+    path <- tempfile()
+    fun(..., file = path)
+    readLines(path, warn = FALSE)
+  }
+  writeLines(
+    c(
+      preamble,
+      capture_report(revdepcheck::cloud_report_summary, pkg = ".", results = results)
+    ),
+    file.path(out_dir, "README.md")
+  )
+  writeLines(
+    capture_report(revdepcheck::cloud_report_problems, pkg = ".", results = results),
+    file.path(out_dir, "problems.md")
+  )
+  writeLines(
+    capture_report(revdepcheck::cloud_report_failures, pkg = ".", results = results),
+    file.path(out_dir, "failures.md")
+  )
+  writeLines(
+    capture_report(revdepcheck::revdep_report_cran, pkg = ".", results = results),
+    file.path(out_dir, "cran.md")
+  )
+  inform("Reports written to ", out_dir)
+} else {
+  inform("revdepcheck is not installed; writing the manifest-derived summary only")
+  df <- data.frame(
+    package = names(entries),
+    version = vapply(entries, function(e) e$version %||% "?", character(1)),
+    result = results_tbl,
+    old = vapply(entries, function(e) e$status_old %||% "", character(1)),
+    new = vapply(entries, function(e) e$status_new %||% "", character(1))
+  )
+  writeLines(
+    c(preamble, "# Revdeps", "", md_table(df)),
+    file.path(out_dir, "README.md")
+  )
+}
+
+# ------------------------------------------------------------------ summary --
+
+tally <- function(what) sum(results_tbl == what)
+counts_df <- data.frame(
+  Result = c("ok", "newly_broken", "failed", "depfail", "error", "deferred"),
+  Packages = c(
+    tally("ok"), tally("newly_broken"), tally("failed"),
+    tally("depfail"), tally("error"), tally("deferred")
+  )
+)
+run_id <- env_chr("GITHUB_RUN_ID")
+append_summary(c(
+  "## revdep2 results",
+  "",
+  sprintf(
+    "`%s` %s (dev) vs %s (CRAN), %d package(s)%s.",
+    plan$package, plan$dev_version, plan$cran_version, length(entries),
+    if (plan$retry_of > 0) sprintf(", retry of run %d", plan$retry_of) else ""
+  ),
+  "",
+  md_table(counts_df),
+  "",
+  readLines(file.path(out_dir, "README.md"), warn = FALSE),
+  "",
+  "### Getting the results",
+  "",
+  "```sh",
+  sprintf("gh run download %s --name revdep2-report --dir revdep/", run_id),
+  sprintf("# retry everything that is not ok:"),
+  sprintf("gh workflow run revdep2.yaml -f retry-run=%s", run_id),
+  "```"
+))
+
+verdict_bad <- switch(
+  fail_on,
+  "none" = character(),
+  "newly-broken" = "newly_broken",
+  "any" = c("newly_broken", "failed", "depfail", "error", "deferred")
+)
+bad <- sum(results_tbl %in% verdict_bad)
+if (bad > 0) {
+  inform(bad, " package(s) fail the run under fail-on=", fail_on)
+  quit(save = "no", status = 1)
+}
+inform("All well under fail-on=", fail_on)

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -237,26 +237,60 @@ if (has_revdepcheck) {
 # ------------------------------------------------------------------ summary --
 
 tally <- function(what) sum(results_tbl == what)
+not_ok <- sum(results_tbl != "ok")
+
+# The one sentence a reader needs, before any table.
+headline <- if (tally("newly_broken") > 0) {
+  sprintf(
+    "**%d of %d packages newly broken.**",
+    tally("newly_broken"), length(entries)
+  )
+} else if (not_ok > 0) {
+  sprintf(
+    "No new breakage; %d of %d packages could not be fully checked.",
+    not_ok, length(entries)
+  )
+} else {
+  sprintf("All good: no new problems in %d packages.", length(entries))
+}
+
 counts_df <- data.frame(
-  Result = c("ok", "newly_broken", "failed", "depfail", "error", "deferred"),
+  Result = c(
+    "ok", "newly broken", "failed to check",
+    "dependencies not installable", "shard error", "deferred"
+  ),
   Packages = c(
     tally("ok"), tally("newly_broken"), tally("failed"),
     tally("depfail"), tally("error"), tally("deferred")
   )
 )
+counts_df <- counts_df[counts_df$Packages > 0 | counts_df$Result == "ok", ]
+
+# The report itself, nested under this section: headings demoted two levels,
+# and the platform preamble dropped -- the sentence above already says what
+# was compared against what.
+readme <- readLines(file.path(out_dir, "README.md"), warn = FALSE)
+revdeps_at <- grep("^# Revdeps", readme)[1]
+if (!is.na(revdeps_at)) {
+  readme <- readme[seq(revdeps_at, length(readme))]
+}
+readme <- gsub("^(#+)(\\s)", "##\\1\\2", readme)
+
 run_id <- env_chr("GITHUB_RUN_ID")
 append_summary(c(
   "## revdep2 results",
   "",
   sprintf(
-    "`%s` %s (dev) vs %s (CRAN), %d package(s)%s.",
-    plan$package, plan$dev_version, plan$cran_version, length(entries),
+    "`%s` %s (dev) vs %s (CRAN), R %s%s.",
+    plan$package, plan$dev_version, plan$cran_version, plan$r_version,
     if (plan$retry_of > 0) sprintf(", retry of run %d", plan$retry_of) else ""
   ),
   "",
+  headline,
+  "",
   md_table(counts_df),
   "",
-  readLines(file.path(out_dir, "README.md"), warn = FALSE),
+  readme,
   "",
   "### Getting the results",
   "",
@@ -267,7 +301,6 @@ append_summary(c(
   "```"
 ))
 
-not_ok <- sum(results_tbl != "ok")
 inform(
   length(entries), " package(s): ", sum(results_tbl == "ok"), " ok, ",
   not_ok, " with findings -- see the summary and the revdep2-report artifact"

--- a/.github/workflows/revdep2/fetch.sh
+++ b/.github/workflows/revdep2/fetch.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Fetch the results of a revdep2 run into revdep/ and show the summary.
+#
+# Usage:
+#   .github/workflows/revdep2/fetch.sh [<run-id>] [<dir>]
+#
+# Without a run id, the newest completed revdep2 run of the current repository
+# is used. Needs the `gh` CLI, authenticated for the repository.
+
+set -eu
+
+run="${1:-}"
+dir="${2:-revdep}"
+
+if [ -z "${run}" ]; then
+  run="$(gh run list --workflow revdep2.yaml --limit 20 \
+    --json databaseId,status --jq \
+    '[.[] | select(.status == "completed")][0].databaseId')"
+  if [ -z "${run}" ] || [ "${run}" = "null" ]; then
+    echo "No completed revdep2 run found; pass a run id." >&2
+    exit 1
+  fi
+  echo "Using newest completed revdep2 run: ${run}"
+fi
+
+mkdir -p "${dir}"
+gh run download "${run}" --name revdep2-report --dir "${dir}"
+
+echo
+echo "Results of run ${run} are in ${dir}/:"
+ls "${dir}"
+echo
+if [ -f "${dir}/README.md" ]; then
+  cat "${dir}/README.md"
+fi
+echo
+echo "To re-check everything that is not ok:"
+echo "  gh workflow run revdep2.yaml -f retry-run=${run}"

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -1,0 +1,541 @@
+# Plan the sharded reverse-dependency check.
+#
+# Enumerates the reverse dependencies of the package in the current directory,
+# weighs each one by the time CRAN's own check machine spends on it, decides
+# which CRAN-baseline results from an earlier run can be reused, and partitions
+# the packages into cost-balanced shards. One shard becomes one matrix leg of
+# .github/workflows/revdep2.yaml.
+#
+# The partitioning is greedy, in two phases (see revdep2/README.md for why
+# greedy beats an exact formulation here):
+#
+#   1. The K heaviest packages are dealt round-robin, one per shard, so no two
+#      giants share a leg.
+#   2. Every remaining package, heaviest first, goes to the shard where its
+#      marginal cost is smallest: its own check weight plus an install penalty
+#      for each dependency the shard does not already need. The penalty is what
+#      pulls packages with overlapping dependency trees onto the same shard.
+#
+# K itself is the smallest shard count whose average check load fits the
+# per-shard budget, capped by the matrix limit -- so wall clock is bought with
+# more shards until the budget says the shards are small enough.
+#
+# Environment variables (inputs):
+#   REVDEP2_PACKAGES        - explicit packages to check (comma/space separated;
+#                             default: all reverse dependencies)
+#   REVDEP2_WHICH           - "strong" (default) or "most" (adds Suggests/
+#                             Enhances dependents)
+#   REVDEP2_RETRY_RUN       - run id of an earlier revdep2 run; check only the
+#                             packages that run could not declare ok
+#   REVDEP2_SHARD_BUDGET_MINUTES - check-time target per shard (default: 45)
+#   REVDEP2_MAX_SHARDS      - matrix legs to emit at most (default: 250)
+#   REVDEP2_MAX_PARALLEL    - legs to run concurrently (default: 20)
+#   REVDEP2_REFRESH_BASELINE- if truthy, ignore reusable baselines and re-check
+#                             the CRAN version of everything
+#   REVDEP2_BASELINE_MAX_AGE_DAYS - oldest baseline worth reusing (default: 30)
+#   REVDEP2_INSTALL_SECONDS - marginal install cost charged per dependency a
+#                             package adds to its shard (default: 2.5)
+#   REVDEP2_TIMINGS_FILE    - offline hook: RDS or CSV with columns Package and
+#                             T_total, used instead of tools::CRAN_check_results()
+#   OUT                     - plan file to write (default: plan.json)
+#
+# Also reads GITHUB_REPOSITORY / GITHUB_SHA / GITHUB_REF_NAME and, for baseline
+# discovery, uses the `gh` CLI with GH_TOKEN. Without gh or a token the plan
+# simply reuses nothing.
+
+source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+
+out_path <- env_chr("OUT", "plan.json")
+which_input <- match.arg(env_chr("REVDEP2_WHICH", "strong"), c("strong", "most"))
+budget <- env_num("REVDEP2_SHARD_BUDGET_MINUTES", 45)
+max_shards <- min(env_num("REVDEP2_MAX_SHARDS", 250), 250)
+max_parallel <- env_num("REVDEP2_MAX_PARALLEL", 20)
+refresh_baseline <- env_flag("REVDEP2_REFRESH_BASELINE")
+baseline_max_age <- env_num("REVDEP2_BASELINE_MAX_AGE_DAYS", 30)
+install_seconds <- env_num("REVDEP2_INSTALL_SECONDS", 2.5)
+setup_minutes <- env_num("REVDEP2_SETUP_MINUTES", 6)
+overhead_minutes <- env_num("REVDEP2_PACKAGE_OVERHEAD_MINUTES", 0.5)
+retry_run <- env_chr("REVDEP2_RETRY_RUN")
+repo <- env_chr("GITHUB_REPOSITORY")
+timing_flavor <- env_chr("REVDEP2_TIMING_FLAVOR", "r-release-linux-x86_64")
+
+r_version <- paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = ".")
+
+# ------------------------------------------------------------ empty plans ----
+
+plan_nothing <- function(reason) {
+  inform("Planning nothing: ", reason)
+  set_output("matrix", '{"shard":["none"]}')
+  set_output("shards", "0")
+  set_output("packages", "0")
+  set_output("max_parallel", "1")
+  set_output("baseline_run", "0")
+  set_output("plan_hash", "none")
+  append_summary(c("## revdep2 plan", "", paste0("Nothing to check: ", reason)))
+  quit(save = "no", status = 0)
+}
+
+# --------------------------------------------------------------- gh helper ----
+
+gh_ok <- nzchar(Sys.which("gh")) && nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
+
+gh_lines <- function(...) {
+  out <- suppressWarnings(system2("gh", c(...), stdout = TRUE, stderr = NULL))
+  if (!is.null(attr(out, "status")) && attr(out, "status") != 0) NULL else out
+}
+
+# Fetch one artifact of one run into a directory; NULL when it does not exist,
+# has expired, or cannot be downloaded.
+fetch_artifact <- function(run_id, name, dest) {
+  if (!gh_ok || !nzchar(repo)) {
+    return(NULL)
+  }
+  ids <- gh_lines(
+    "api",
+    sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", repo, run_id),
+    "--jq",
+    sprintf('.artifacts[] | select(.name == "%s" and .expired == false) | .id', name)
+  )
+  if (length(ids) == 0 || !nzchar(ids[[1]])) {
+    return(NULL)
+  }
+  zip <- tempfile(fileext = ".zip")
+  status <- suppressWarnings(system2(
+    "gh",
+    c("api", sprintf("repos/%s/actions/artifacts/%s/zip", repo, ids[[1]])),
+    stdout = zip,
+    stderr = NULL
+  ))
+  if (!identical(status, 0L) || !file.exists(zip)) {
+    return(NULL)
+  }
+  dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+  utils::unzip(zip, exdir = dest)
+  unlink(zip)
+  dest
+}
+
+# Newest completed run of this workflow that still holds a baseline artifact.
+find_baseline_run <- function() {
+  if (!gh_ok || !nzchar(repo)) {
+    return(NULL)
+  }
+  runs <- gh_lines(
+    "api",
+    sprintf(
+      "repos/%s/actions/workflows/revdep2.yaml/runs?status=completed&per_page=40",
+      repo
+    ),
+    "--jq",
+    ".workflow_runs[].id"
+  )
+  this_run <- env_chr("GITHUB_RUN_ID")
+  for (run in setdiff(as.character(runs), this_run)) {
+    hits <- gh_lines(
+      "api",
+      sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", repo, run),
+      "--jq",
+      '.artifacts[] | select(.name == "revdep2-baseline" and .expired == false) | .id'
+    )
+    if (length(hits) > 0 && nzchar(hits[[1]])) {
+      return(run)
+    }
+  }
+  NULL
+}
+
+# ------------------------------------------------- the package under test ----
+
+desc <- read.dcf("DESCRIPTION")[1, ]
+package <- unname(desc[["Package"]])
+dev_version <- unname(desc[["Version"]])
+inform("Package under test: ", package, " ", dev_version)
+
+db <- cran_db()
+if (!package %in% rownames(db)) {
+  plan_nothing(sprintf("%s is not on CRAN, so it has no CRAN reverse dependencies", package))
+}
+cran_version <- unname(db[package, "Version"])
+inform("CRAN version: ", cran_version)
+
+# ------------------------------------------------------------- enumeration ---
+
+revdeps <- sort(tools::package_dependencies(
+  package,
+  db = db,
+  which = if (which_input == "most") "most" else "strong",
+  reverse = TRUE
+)[[1]])
+inform(length(revdeps), " reverse dependencies (", which_input, ")")
+
+selection <- "all"
+retry_manifest <- NULL
+packages_input <- trimws(strsplit(env_chr("REVDEP2_PACKAGES"), "[,[:space:]]+")[[1]])
+packages_input <- packages_input[nzchar(packages_input)]
+
+if (length(packages_input) > 0) {
+  selection <- "explicit"
+  candidates <- unique(packages_input)
+} else if (nzchar(retry_run)) {
+  selection <- sprintf("retry of run %s", retry_run)
+  dir <- fetch_artifact(retry_run, "revdep2-report", tempfile("retry-"))
+  manifest_path <- if (is.null(dir)) NULL else file.path(dir, "manifest.json")
+  if (is.null(manifest_path) || !file.exists(manifest_path)) {
+    stop("Cannot fetch the revdep2-report artifact of run ", retry_run, call. = FALSE)
+  }
+  retry_manifest <- read_json(manifest_path)
+  results <- vapply(retry_manifest, function(e) e$result, character(1))
+  candidates <- vapply(retry_manifest, function(e) e$package, character(1))[
+    vapply(results, needs_recheck, logical(1))
+  ]
+  inform(
+    "Retrying ", length(candidates), " of ", length(retry_manifest),
+    " packages from run ", retry_run
+  )
+} else {
+  candidates <- revdeps
+}
+
+dropped <- setdiff(candidates, rownames(db))
+if (length(dropped) > 0) {
+  inform("Not on CRAN, dropped: ", paste(dropped, collapse = ", "))
+}
+packages <- intersect(candidates, rownames(db))
+if (length(packages) == 0) {
+  plan_nothing("no packages left to check")
+}
+their_version <- setNames(unname(db[packages, "Version"]), packages)
+
+# ------------------------------------------------------------------ weights --
+
+timings_file <- env_chr("REVDEP2_TIMINGS_FILE")
+if (nzchar(timings_file)) {
+  inform("Reading check timings from ", timings_file)
+  timings <- if (grepl("[.]rds$", timings_file)) {
+    readRDS(timings_file)
+  } else {
+    utils::read.csv(timings_file)
+  }
+} else {
+  inform("Fetching CRAN check timings (flavor ", timing_flavor, ")")
+  timings <- tools::CRAN_check_results()
+  timings <- timings[timings$Flavor == timing_flavor, c("Package", "T_total")]
+}
+t_total <- setNames(
+  as.numeric(timings$T_total)[match(packages, timings$Package)],
+  packages
+)
+known <- !is.na(t_total)
+fallback <- if (any(known)) stats::median(t_total[known]) else 300
+t_total[!known] <- fallback
+t_total <- pmax(t_total, 60)
+inform(
+  sum(known), " of ", length(packages), " check times known from CRAN; ",
+  "median fallback ", round(fallback), "s for the rest"
+)
+
+# --------------------------------------------------------------- closures ----
+
+inform("Computing dependency closures")
+closure <- install_closure(packages, db)
+fingerprint <- vapply(
+  packages,
+  function(p) dep_fingerprint(closure[[p]], db),
+  character(1)
+)
+
+# The dev version's own dependencies: every shard installs the dev binary, so
+# every shard needs them even when no revdep pulls them in. Parsed from the
+# checkout's DESCRIPTION, resolved against CRAN.
+parse_dep_field <- function(field) {
+  value <- desc[field]
+  if (is.na(value)) {
+    return(character())
+  }
+  entries <- strsplit(value, ",")[[1]]
+  names <- trimws(sub("[([].*$", "", entries))
+  names[nzchar(names) & names != "R"]
+}
+dev_deps <- unique(unlist(lapply(c("Depends", "Imports", "LinkingTo"), parse_dep_field)))
+dev_deps <- intersect(dev_deps, rownames(db))
+dev_closure <- sort(setdiff(
+  unique(c(
+    dev_deps,
+    unlist(
+      tools::package_dependencies(dev_deps, db = db, which = "strong", recursive = TRUE),
+      use.names = FALSE
+    )
+  )),
+  base_packages()
+))
+
+# ---------------------------------------------------------------- baseline ---
+
+baseline_run <- 0L
+baseline_manifest <- list()
+local_baseline <- env_chr("REVDEP2_BASELINE_DIR")
+if (refresh_baseline) {
+  inform("Baseline reuse disabled by input")
+} else if (nzchar(local_baseline)) {
+  # Offline hook for testing the eligibility rules without a GitHub run: a
+  # directory holding baseline.json, e.g. a downloaded revdep2-baseline
+  # artifact. The shard reads the same directory through BASELINE_DIR.
+  manifest_path <- file.path(local_baseline, "baseline.json")
+  if (file.exists(manifest_path)) {
+    entries <- read_json(manifest_path)
+    baseline_manifest <- setNames(
+      entries,
+      vapply(entries, function(e) e$package, character(1))
+    )
+    inform("Baseline from ", local_baseline, " (", length(baseline_manifest), " entries)")
+  }
+} else {
+  donor <- if (nzchar(retry_run)) retry_run else find_baseline_run()
+  if (is.null(donor) || !nzchar(donor)) {
+    inform("No earlier run with a baseline artifact found")
+  } else {
+    dir <- fetch_artifact(donor, "revdep2-baseline", tempfile("baseline-"))
+    manifest_path <- if (is.null(dir)) NULL else file.path(dir, "baseline.json")
+    if (is.null(manifest_path) || !file.exists(manifest_path)) {
+      inform("Baseline artifact of run ", donor, " is unavailable; reusing nothing")
+    } else {
+      baseline_run <- as.integer(donor)
+      entries <- read_json(manifest_path)
+      baseline_manifest <- setNames(
+        entries,
+        vapply(entries, function(e) e$package, character(1))
+      )
+      inform("Baseline donor: run ", donor, " (", length(baseline_manifest), " entries)")
+    }
+  }
+}
+
+# Reuse an old-version verdict only when everything that shaped it is
+# unchanged: the revdep's version, the CRAN version of the package under test,
+# the R series, and the resolved versions of the whole install closure -- plus
+# an age cap as the backstop for what metadata cannot see (system libraries,
+# the runner image).
+baseline_verdict <- function(p) {
+  e <- baseline_manifest[[p]]
+  if (is.null(e)) {
+    return("none")
+  }
+  if (!identical(e$version, unname(their_version[[p]]))) {
+    return("their-version")
+  }
+  if (!identical(e$our_cran_version, cran_version)) {
+    return("our-version")
+  }
+  if (!identical(e$r_version, r_version)) {
+    return("r-version")
+  }
+  if (!identical(e$dep_fingerprint, unname(fingerprint[[p]]))) {
+    return("dependencies")
+  }
+  checked <- suppressWarnings(as.Date(e$checked_at))
+  if (is.na(checked) || as.numeric(Sys.Date() - checked) > baseline_max_age) {
+    return("age")
+  }
+  if (!isTRUE(e$has_old)) {
+    return("missing-rds")
+  }
+  "reuse"
+}
+verdicts <- vapply(packages, baseline_verdict, character(1))
+reuse <- verdicts == "reuse"
+if (baseline_run > 0) {
+  stale <- table(verdicts[!reuse])
+  inform(
+    "Baseline: ", sum(reuse), " reusable, ",
+    sum(!reuse), " to check fresh",
+    if (length(stale) > 0) {
+      paste0(" (", paste(names(stale), stale, sep = ": ", collapse = ", "), ")")
+    } else {
+      ""
+    }
+  )
+}
+
+# Weight: one check of the revdep costs about what CRAN's Linux machine spends
+# on it end to end; a package without a reusable baseline is checked twice.
+weight <- ((!reuse) + 1) * t_total / 60 + overhead_minutes
+
+# ------------------------------------------------------------- partitioning --
+
+n <- length(packages)
+total_check <- sum(weight)
+k <- max(1L, min(as.integer(ceiling(total_check / budget)), max_shards, n))
+inform(
+  sprintf(
+    "%d packages, ~%.0f check minutes, budget %.0f min/shard -> %d shard(s)",
+    n, total_check, budget, k
+  )
+)
+
+universe <- unique(c(unlist(closure, use.names = FALSE), dev_closure))
+dep_idx <- lapply(closure, function(deps) match(deps, universe))
+penalty <- install_seconds / 60
+
+ord <- order(-weight)
+assignment <- integer(n)
+load <- rep(setup_minutes + length(dev_closure) * penalty, k)
+check_load <- numeric(k)
+install_count <- rep(length(dev_closure), k)
+have <- matrix(FALSE, nrow = length(universe), ncol = k)
+have[match(dev_closure, universe), ] <- TRUE
+
+place <- function(i, s) {
+  p <- ord[[i]]
+  fresh <- sum(!have[dep_idx[[p]], s])
+  assignment[[p]] <<- s
+  check_load[[s]] <<- check_load[[s]] + weight[[p]]
+  load[[s]] <<- load[[s]] + weight[[p]] + fresh * penalty
+  install_count[[s]] <<- install_count[[s]] + fresh
+  have[dep_idx[[p]], s] <<- TRUE
+}
+
+# Phase 1: the K heaviest packages, dealt round-robin.
+for (i in seq_len(min(k, n))) {
+  place(i, i)
+}
+
+# Phase 2: everything else goes where it costs least, dependency reuse folded
+# into the price.
+if (n > k) {
+  for (i in seq(k + 1L, n)) {
+    p <- ord[[i]]
+    fresh <- colSums(!have[dep_idx[[p]], , drop = FALSE])
+    score <- load + weight[[p]] + fresh * penalty
+    place(i, which.min(score))
+  }
+}
+
+# ------------------------------------------------------------------ output ---
+
+shard_list <- lapply(seq_len(k), function(s) {
+  members <- packages[assignment == s]
+  members <- members[order(-weight[members])]
+  install <- sort(unique(c(
+    dev_closure,
+    unlist(closure[members], use.names = FALSE)
+  )))
+  list(
+    index = s,
+    estimate_minutes = round(load[[s]], 1),
+    check_minutes = round(check_load[[s]], 1),
+    install_packages = length(install),
+    install = as.list(install),
+    packages = lapply(members, function(p) {
+      list(
+        name = p,
+        version = unname(their_version[[p]]),
+        weight_minutes = round(unname(weight[[p]]), 2),
+        t_total = unname(t_total[[p]]),
+        timing_source = if (known[[match(p, packages)]]) "cran" else "median",
+        dep_fingerprint = unname(fingerprint[[p]]),
+        baseline = unname(reuse[[p]])
+      )
+    })
+  )
+})
+
+plan <- list(
+  package = package,
+  dev_version = dev_version,
+  cran_version = cran_version,
+  r_version = r_version,
+  sha = env_chr("GITHUB_SHA"),
+  ref = env_chr("GITHUB_REF_NAME"),
+  which = which_input,
+  selection = selection,
+  generated_at = now_utc(),
+  timing_flavor = timing_flavor,
+  retry_of = if (nzchar(retry_run)) as.integer(retry_run) else 0L,
+  baseline = list(
+    run_id = baseline_run,
+    max_age_days = baseline_max_age,
+    reused = sum(reuse),
+    fresh = sum(!reuse)
+  ),
+  params = list(
+    shard_budget_minutes = budget,
+    max_shards = max_shards,
+    max_parallel = max_parallel,
+    install_seconds_per_package = install_seconds,
+    setup_minutes = setup_minutes,
+    package_overhead_minutes = overhead_minutes
+  ),
+  totals = list(
+    revdeps = length(revdeps),
+    packages = n,
+    check_minutes = round(total_check, 1),
+    estimate_minutes = round(sum(load), 1),
+    install_union = length(universe)
+  ),
+  dropped_unknown = as.list(dropped),
+  install_union = as.list(sort(universe)),
+  dev_closure = as.list(dev_closure),
+  shards = shard_list
+)
+write_json(plan, out_path)
+plan_hash <- unname(tools::md5sum(out_path))
+inform("Plan written to ", out_path)
+
+parallel <- max(1L, min(as.integer(max_parallel), k))
+matrix <- list(
+  include = lapply(shard_list, function(s) {
+    list(
+      shard = s$index,
+      label = sprintf("%d pkgs, ~%.0f min", length(s$packages), s$estimate_minutes)
+    )
+  })
+)
+
+set_output("matrix", jsonlite::toJSON(matrix, auto_unbox = TRUE))
+set_output("shards", as.character(k))
+set_output("packages", as.character(n))
+set_output("max_parallel", as.character(parallel))
+set_output("baseline_run", as.character(baseline_run))
+set_output("plan_hash", plan_hash)
+
+# ------------------------------------------------------------------ summary --
+
+top <- function(s) {
+  names <- vapply(s$packages, function(p) p$name, character(1))
+  paste(utils::head(names, 3), collapse = ", ")
+}
+summary_df <- data.frame(
+  Shard = vapply(shard_list, function(s) s$index, integer(1)),
+  Packages = vapply(shard_list, function(s) length(s$packages), integer(1)),
+  `Check est.` = sprintf("~%.0f min", vapply(shard_list, function(s) s$check_minutes, numeric(1))),
+  `Total est.` = sprintf("~%.0f min", vapply(shard_list, function(s) s$estimate_minutes, numeric(1))),
+  Installs = vapply(shard_list, function(s) s$install_packages, integer(1)),
+  Heaviest = vapply(shard_list, top, character(1)),
+  check.names = FALSE
+)
+append_summary(c(
+  "## revdep2 plan",
+  "",
+  "| | |",
+  "| --- | --- |",
+  sprintf("| Package | `%s` %s (CRAN: %s) |", package, dev_version, cran_version),
+  sprintf("| Selection | %s |", selection),
+  sprintf("| Packages to check | %d (of %d revdeps) |", n, length(revdeps)),
+  sprintf(
+    "| Baseline | %s |",
+    if (length(baseline_manifest) > 0) {
+      sprintf(
+        "%s: %d reused, %d fresh",
+        if (baseline_run > 0) sprintf("run %d", baseline_run) else "local",
+        sum(reuse),
+        sum(!reuse)
+      )
+    } else {
+      "none"
+    }
+  ),
+  sprintf("| Shards | %d (max-parallel %d, budget %.0f min) |", k, parallel, budget),
+  sprintf("| Estimated runner time | ~%.0f min |", sum(load)),
+  "",
+  md_table(summary_df)
+))

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -47,6 +47,15 @@ source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), valu
 
 out_path <- env_chr("OUT", "plan.json")
 which_input <- match.arg(env_chr("REVDEP2_WHICH", "strong"), c("strong", "most"))
+depth_raw <- tolower(env_chr("REVDEP2_DEPTH", "1"))
+depth <- if (depth_raw %in% c("all", "max", "inf", "infinity")) {
+  Inf
+} else {
+  suppressWarnings(as.numeric(depth_raw))
+}
+if (is.na(depth) || depth < 1) {
+  depth <- 1
+}
 budget <- env_num("REVDEP2_SHARD_BUDGET_MINUTES", 45)
 max_shards <- min(env_num("REVDEP2_MAX_SHARDS", 250), 250)
 max_parallel <- env_num("REVDEP2_MAX_PARALLEL", 20)
@@ -160,13 +169,39 @@ inform("CRAN version: ", cran_version)
 
 # ------------------------------------------------------------- enumeration ---
 
-revdeps <- sort(tools::package_dependencies(
-  package,
-  db = db,
-  which = if (which_input == "most") "most" else "strong",
-  reverse = TRUE
-)[[1]])
-inform(length(revdeps), " reverse dependencies (", which_input, ")")
+# Breadth-first over reverse dependencies: level 1 depends on the package
+# directly, level 2 on a level-1 package, and so on. Deeper levels break
+# through their intermediaries, so checking them still compares CRAN vs dev
+# meaningfully. The walk stops at `depth`, or at the fixpoint for "all".
+level_of <- integer()
+frontier <- package
+level <- 0L
+while (level < depth && length(frontier) > 0) {
+  found <- tools::package_dependencies(
+    frontier,
+    db = db,
+    which = if (which_input == "most") "most" else "strong",
+    reverse = TRUE
+  )
+  fresh <- setdiff(
+    unique(unlist(found, use.names = FALSE)),
+    c(names(level_of), package)
+  )
+  level <- level + 1L
+  level_of[fresh] <- level
+  frontier <- fresh
+}
+revdeps <- sort(names(level_of))
+level_counts <- table(level_of)
+inform(
+  length(revdeps), " reverse dependencies (", which_input, ", depth ", depth_raw,
+  if (length(level_counts) > 1) {
+    paste0("; ", paste0("level ", names(level_counts), ": ", level_counts, collapse = ", "))
+  } else {
+    ""
+  },
+  ")"
+)
 
 selection <- "all"
 retry_manifest <- NULL
@@ -429,6 +464,7 @@ shard_list <- lapply(seq_len(k), function(s) {
       list(
         name = p,
         version = unname(their_version[[p]]),
+        level = if (p %in% names(level_of)) unname(level_of[[p]]) else 0L,
         weight_minutes = round(unname(weight[[p]]), 2),
         t_total = unname(t_total[[p]]),
         timing_source = if (known[[match(p, packages)]]) "cran" else "median",
@@ -439,14 +475,26 @@ shard_list <- lapply(seq_len(k), function(s) {
   )
 })
 
+# The dispatched ref and the checked-out tree differ when the `ref` input
+# names another branch or SHA; the tree is what is being tested.
+head_sha <- tryCatch(
+  system2("git", c("rev-parse", "HEAD"), stdout = TRUE, stderr = NULL)[[1]],
+  error = function(e) ""
+)
+if (!nzchar(head_sha)) {
+  head_sha <- env_chr("GITHUB_SHA")
+}
+
 plan <- list(
   package = package,
   dev_version = dev_version,
   cran_version = cran_version,
   r_version = r_version,
-  sha = env_chr("GITHUB_SHA"),
+  sha = head_sha,
   ref = env_chr("GITHUB_REF_NAME"),
   which = which_input,
+  depth = depth_raw,
+  levels = as.list(level_counts),
   selection = selection,
   generated_at = now_utc(),
   timing_flavor = timing_flavor,
@@ -516,11 +564,24 @@ summary_df <- data.frame(
 append_summary(c(
   "## revdep2 plan",
   "",
+  if (env_flag("REVDEP2_DRY_RUN")) c("**Dry run: planning only, no checks started.**", ""),
   "| | |",
   "| --- | --- |",
   sprintf("| Package | `%s` %s (CRAN: %s) |", package, dev_version, cran_version),
   sprintf("| Selection | %s |", selection),
-  sprintf("| Packages to check | %d (of %d revdeps) |", n, length(revdeps)),
+  sprintf(
+    "| Packages to check | %d (of %d revdeps%s) |",
+    n,
+    length(revdeps),
+    if (length(level_counts) > 1) {
+      paste0(
+        "; ",
+        paste0("level ", names(level_counts), ": ", level_counts, collapse = ", ")
+      )
+    } else {
+      ""
+    }
+  ),
   sprintf(
     "| Baseline | %s |",
     if (length(baseline_manifest) > 0) {

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -1,0 +1,132 @@
+# Prove the dependency world installs before any shard spends a minute on
+# checks: install the union of every dependency any revdep needs into a
+# scratch library -- which downloads every binary exactly once into the pak
+# cache the workflow then saves for the shards -- and load-test each installed
+# package. Broken or uninstallable dependencies surface here, in depfail.json
+# and the job summary.
+#
+# A dependency failure is a report, not a stop: shards attempt their own
+# subset regardless (their repository snapshot may succeed where this one
+# failed), and a revdep whose dependencies genuinely cannot be installed fails
+# its own check with an install log, which is the result a report can work
+# with.
+#
+# Environment variables:
+#   PLAN     - plan.json from plan.R (default: plan.json)
+#   OUT_DIR  - where depfail.json lands (default: preflight)
+
+source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+
+plan <- read_json(env_chr("PLAN", "plan.json"))
+out_dir <- env_chr("OUT_DIR", "preflight")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+install_union <- unlist(plan$install_union, use.names = FALSE)
+
+lib <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-preflight-lib")
+dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+failures <- list()
+
+inform("Preflight: installing ", length(install_union), " packages")
+installed_ok <- tryCatch(
+  {
+    pak::pkg_install(install_union, lib = lib, ask = FALSE)
+    TRUE
+  },
+  error = function(e) {
+    inform("Bulk install failed: ", conditionMessage(e))
+    FALSE
+  }
+)
+if (!installed_ok) {
+  # One bad package must not hide the state of the other thousand: retry each
+  # missing package on its own and record exactly which ones will not install.
+  for (p in install_union) {
+    if (dir.exists(file.path(lib, p))) {
+      next
+    }
+    result <- tryCatch(
+      {
+        pak::pkg_install(p, lib = lib, ask = FALSE)
+        NULL
+      },
+      error = function(e) conditionMessage(e)
+    )
+    if (!is.null(result)) {
+      failures[[length(failures) + 1]] <- list(
+        package = p,
+        phase = "install",
+        message = result
+      )
+    }
+  }
+}
+
+# Load every installed dependency, in chunks small enough to stay clear of the
+# DLL limit; a failing chunk is retried one package at a time so a single bad
+# namespace names itself.
+installed <- intersect(install_union, rownames(utils::installed.packages(lib)))
+inform("Preflight: loading ", length(installed), " packages")
+load_batch <- function(pkgs) {
+  script <- tempfile(fileext = ".R")
+  writeLines(
+    c(
+      sprintf(".libPaths(c(%s, .libPaths()))", deparse(lib)),
+      "for (p in commandArgs(trailingOnly = TRUE)) {",
+      "  loadNamespace(p)",
+      "  writeLines(paste0('LOADED ', p))",
+      "}"
+    ),
+    script
+  )
+  out <- suppressWarnings(system2(
+    "Rscript",
+    c("--vanilla", script, pkgs),
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+  loaded <- sub("^LOADED ", "", grep("^LOADED ", out, value = TRUE))
+  list(failed = setdiff(pkgs, loaded), log = out)
+}
+chunks <- split(installed, ceiling(seq_along(installed) / 40))
+for (chunk in chunks) {
+  first <- load_batch(chunk)
+  if (length(first$failed) == 0) {
+    next
+  }
+  for (p in first$failed) {
+    single <- load_batch(p)
+    if (length(single$failed) > 0) {
+      failures[[length(failures) + 1]] <- list(
+        package = p,
+        phase = "load",
+        message = paste(utils::tail(sanitize_log(single$log), 20), collapse = "\n")
+      )
+    }
+  }
+}
+
+write_json(failures, file.path(out_dir, "depfail.json"))
+
+append_summary(c(
+  "## revdep2 preflight",
+  "",
+  sprintf(
+    "Installed and loaded %d dependencies: %d could not be installed or loaded.",
+    length(install_union), length(failures)
+  ),
+  ""
+))
+if (length(failures) > 0) {
+  df <- data.frame(
+    Package = vapply(failures, function(f) f$package, character(1)),
+    Phase = vapply(failures, function(f) f$phase, character(1))
+  )
+  append_summary(md_table(df))
+  for (f in failures) {
+    append_summary(md_details(
+      sprintf("<code>%s</code> &mdash; %s failure", f$package, f$phase),
+      strsplit(f$message, "\n")[[1]]
+    ))
+  }
+  inform(length(failures), " dependencies failed preflight; see depfail.json")
+}

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -25,7 +25,10 @@
 #                            may be missing or empty, then everything is fresh
 #   OUT_DIR                - results directory, uploaded as the shard artifact
 #                            (default: results)
-#   CHECK_TIMEOUT_MINUTES  - hard cap per rcmdcheck call (default: 30)
+#   TIMEOUT_FACTOR         - per-check timeout as a multiple of the package's
+#                            CRAN check time (default: 1.5)
+#   TIMEOUT_MIN_MINUTES    - floor for that timeout; CRAN's machines are not
+#                            these runners (default: 10)
 #   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
 
 source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
@@ -36,7 +39,8 @@ plan <- read_json(env_chr("PLAN", "plan.json"))
 pkg_dir <- env_chr("PKG_DIR", "pkg")
 baseline_dir <- env_chr("BASELINE_DIR", "baseline")
 out_dir <- env_chr("OUT_DIR", "results")
-timeout_sec <- env_num("CHECK_TIMEOUT_MINUTES", 30) * 60
+timeout_factor <- env_num("TIMEOUT_FACTOR", 1.5)
+timeout_min_sec <- env_num("TIMEOUT_MIN_MINUTES", 10) * 60
 deadline <- Sys.time() + env_num("DEADLINE_MINUTES", 300) * 60
 
 shard <- Filter(function(s) s$index == shard_index, plan$shards)[[1]]
@@ -63,8 +67,10 @@ for (p in shard$packages) {
     list(
       package = p$name,
       version = p$version,
+      level = p$level %||% 0L,
       shard = shard_index,
       weight_minutes = p$weight_minutes,
+      t_total = p$t_total %||% 0,
       dep_fingerprint = p$dep_fingerprint,
       baseline_planned = isTRUE(p$baseline),
       baseline_reused = FALSE,
@@ -217,6 +223,13 @@ run_check <- function(name, phase) {
   checks_started <<- checks_started + 1L
   check_dir <- file.path(work, "check", name, phase)
   dir.create(check_dir, recursive = TRUE, showWarnings = FALSE)
+  # The timeout scales with what the check costs CRAN, floored because these
+  # runners are slower than CRAN's machines and a tiny package must not be
+  # killed over the difference.
+  timeout_sec <- max(
+    timeout_min_sec,
+    timeout_factor * (get(name, envir = state)$t_total %||% 0)
+  )
   started <- Sys.time()
   result <- tryCatch(
     rcmdcheck::rcmdcheck(
@@ -228,8 +241,29 @@ run_check <- function(name, phase) {
     ),
     error = function(e) e
   )
-  attr(result, "duration") <- round(as.numeric(Sys.time() - started, units = "secs"))
+  duration <- round(as.numeric(Sys.time() - started, units = "secs"))
+  attr(result, "duration") <- duration
+  # A check that hits the timeout is killed, and rcmdcheck surfaces that as an
+  # error rather than a result object; tell it apart from a genuine crash by
+  # the clock.
+  attr(result, "timed_out") <- inherits(result, "error") && duration >= timeout_sec - 1
   result
+}
+
+check_failure <- function(name, phase, result) {
+  if (isTRUE(attr(result, "timed_out"))) {
+    update(
+      name,
+      result = "failed",
+      message = sprintf(
+        "%s check timed out after %ds", phase, attr(result, "duration")
+      )
+    )
+    inform(name, ": ", phase, " check timed out (", attr(result, "duration"), "s)")
+  } else {
+    update(name, result = "error", message = conditionMessage(result))
+    inform(name, ": ", phase, " check errored: ", conditionMessage(result))
+  }
 }
 
 pkg_out <- function(name) {
@@ -272,8 +306,7 @@ for (name in runnable) {
     }
     old <- run_check(name, "old")
     if (inherits(old, "error")) {
-      update(name, result = "error", message = conditionMessage(old))
-      inform(name, ": old check errored: ", conditionMessage(old))
+      check_failure(name, "old", old)
       next
     }
     saveRDS(old, file.path(pkg_out(name), "old.rds"))
@@ -311,8 +344,7 @@ for (name in runnable) {
   }
   new <- run_check(name, "new")
   if (inherits(new, "error")) {
-    update(name, result = "error", message = conditionMessage(new))
-    inform(name, ": new check errored: ", conditionMessage(new))
+    check_failure(name, "new", new)
     next
   }
   saveRDS(new, file.path(pkg_out(name), "new.rds"))

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -1,0 +1,428 @@
+# Check one shard of a revdep2 plan: many reverse dependencies, one job, one
+# shared library.
+#
+# The shard installs the union of its packages' dependencies once, then walks
+# its packages in two phases: every package is checked against the CRAN version
+# of the package under test (or its baseline result is reused), the dev binary
+# is installed over the CRAN version, and every package is checked again. The
+# two rcmdcheck results are compared per package, revdepcheck-style.
+#
+# Failure is data here, never a job failure: a package that breaks, times out,
+# or cannot even install its dependencies gets a manifest entry saying so, and
+# the walk continues. The job goes red only when the driver itself is broken.
+#
+# The shard stops starting new checks when its deadline says the next one will
+# not finish, and records the rest as deferred; a later run started with
+# `retry-run` picks exactly those up. Results that exist by then -- including
+# an old-version result whose new-version counterpart was cut off -- are still
+# uploaded, so nothing decided is lost to the deadline.
+#
+# Environment variables:
+#   SHARD                  - shard index from plan.json (required)
+#   PLAN                   - plan file (default: plan.json)
+#   PKG_DIR                - the revdep2-pkg artifact: meta.json, bin/ (required)
+#   BASELINE_DIR           - the revdep2-baseline artifact of the donor run;
+#                            may be missing or empty, then everything is fresh
+#   OUT_DIR                - results directory, uploaded as the shard artifact
+#                            (default: results)
+#   CHECK_TIMEOUT_MINUTES  - hard cap per rcmdcheck call (default: 30)
+#   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
+
+source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+
+shard_index <- as.integer(env_chr("SHARD"))
+stopifnot(!is.na(shard_index))
+plan <- read_json(env_chr("PLAN", "plan.json"))
+pkg_dir <- env_chr("PKG_DIR", "pkg")
+baseline_dir <- env_chr("BASELINE_DIR", "baseline")
+out_dir <- env_chr("OUT_DIR", "results")
+timeout_sec <- env_num("CHECK_TIMEOUT_MINUTES", 30) * 60
+deadline <- Sys.time() + env_num("DEADLINE_MINUTES", 300) * 60
+
+shard <- Filter(function(s) s$index == shard_index, plan$shards)[[1]]
+members <- vapply(shard$packages, function(p) p$name, character(1))
+meta <- read_json(file.path(pkg_dir, "meta.json"))
+package <- plan$package
+
+dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
+manifest_path <- file.path(out_dir, "manifest.ndjson")
+file.create(manifest_path)
+work <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-work")
+dir.create(work, recursive = TRUE, showWarnings = FALSE)
+
+inform(
+  "Shard ", shard_index, ": ", length(members), " package(s), ",
+  "estimated ~", shard$estimate_minutes, " min"
+)
+
+# The running state per package; every entry ends up as one manifest line.
+state <- new.env(parent = emptyenv())
+for (p in shard$packages) {
+  assign(
+    p$name,
+    list(
+      package = p$name,
+      version = p$version,
+      shard = shard_index,
+      weight_minutes = p$weight_minutes,
+      dep_fingerprint = p$dep_fingerprint,
+      baseline_planned = isTRUE(p$baseline),
+      baseline_reused = FALSE,
+      result = "deferred",
+      status = "",
+      status_old = "",
+      status_new = "",
+      new_issues = 0L,
+      t_old = NA,
+      t_new = NA,
+      old_checked_at = NA,
+      message = ""
+    ),
+    envir = state
+  )
+}
+update <- function(name, ...) {
+  entry <- get(name, envir = state)
+  entry[names(list(...))] <- list(...)
+  assign(name, entry, envir = state)
+  entry
+}
+
+counts <- function(x) {
+  if (!inherits(x, "rcmdcheck")) {
+    return("?")
+  }
+  sprintf(
+    "%dE %dW %dN",
+    length(x$errors), length(x$warnings), length(x$notes)
+  )
+}
+
+# ---------------------------------------------------------------- install ----
+
+install <- unlist(shard$install, use.names = FALSE)
+inform("Installing ", length(install), " dependencies")
+bulk_ok <- tryCatch(
+  {
+    pak::pkg_install(install, ask = FALSE)
+    TRUE
+  },
+  error = function(e) {
+    inform("Bulk install failed: ", conditionMessage(e))
+    FALSE
+  }
+)
+if (!bulk_ok) {
+  for (p in install) {
+    if (requireNamespace(p, quietly = TRUE)) {
+      next
+    }
+    tryCatch(
+      pak::pkg_install(p, ask = FALSE),
+      error = function(e) inform("Could not install ", p, ": ", conditionMessage(e))
+    )
+  }
+}
+
+installed <- rownames(utils::installed.packages())
+our_version <- function() {
+  tryCatch(as.character(utils::packageVersion(package)), error = function(e) NA_character_)
+}
+our_cran_version <- our_version()
+if (!identical(our_cran_version, plan$cran_version)) {
+  # The library must hold the *CRAN release* for the old phase; the resolver
+  # may have kept some other version it found satisfactory.
+  inform(
+    "Installed version is ", our_cran_version, ", plan expected ",
+    plan$cran_version, "; reinstalling from the repositories"
+  )
+  utils::install.packages(package)
+  our_cran_version <- our_version()
+  if (!identical(our_cran_version, plan$cran_version)) {
+    inform(
+      "Note: old checks run against ", our_cran_version,
+      " (the repositories lag CRAN)"
+    )
+  }
+}
+
+# A package whose *strong* dependency closure is incomplete cannot produce a
+# check result worth comparing; missing suggests are tolerable, the check runs
+# with _R_CHECK_FORCE_SUGGESTS_=false, the way CRAN treats unavailable ones.
+db <- cran_db()
+strong_missing <- function(name) {
+  strong <- tools::package_dependencies(name, db = db, which = "strong", recursive = TRUE)[[1]]
+  setdiff(intersect(strong, rownames(db)), c(installed, base_packages()))
+}
+runnable <- character()
+for (name in members) {
+  missing <- tryCatch(strong_missing(name), error = function(e) character())
+  if (length(missing) > 0) {
+    update(
+      name,
+      result = "depfail",
+      message = paste("Dependencies not installed:", paste(missing, collapse = ", "))
+    )
+    inform(name, ": dependencies missing (", paste(missing, collapse = ", "), ")")
+  } else {
+    runnable <- c(runnable, name)
+  }
+}
+
+# ---------------------------------------------------------------- sources ----
+
+src_dir <- file.path(work, "src")
+dir.create(src_dir, showWarnings = FALSE)
+sources <- list()
+for (name in runnable) {
+  tarball <- tryCatch(
+    {
+      hit <- utils::download.packages(
+        name,
+        destdir = src_dir,
+        repos = cran_repo(),
+        type = "source",
+        quiet = TRUE
+      )
+      hit[1, 2]
+    },
+    error = function(e) NULL
+  )
+  if (is.null(tarball)) {
+    update(name, result = "error", message = "Source tarball could not be downloaded")
+    inform(name, ": source download failed")
+  } else {
+    sources[[name]] <- tarball
+    actual <- sub(sprintf("^%s_(.*)[.]tar[.]gz$", name), "\\1", basename(tarball))
+    update(name, version = actual)
+  }
+}
+runnable <- names(sources)
+
+# ------------------------------------------------------------------ checks ---
+
+# Stop before a check the trailing estimate says will not finish -- but always
+# attempt the first check of a phase, or a mis-budgeted shard would make no
+# progress at all and a retry would repeat the mistake.
+checks_started <- 0L
+out_of_time <- function(entry) {
+  if (checks_started == 0L) {
+    return(FALSE)
+  }
+  budget_sec <- max(entry$weight_minutes, 1) * 60 * 1.3
+  Sys.time() + budget_sec > deadline
+}
+
+run_check <- function(name, phase) {
+  checks_started <<- checks_started + 1L
+  check_dir <- file.path(work, "check", name, phase)
+  dir.create(check_dir, recursive = TRUE, showWarnings = FALSE)
+  started <- Sys.time()
+  result <- tryCatch(
+    rcmdcheck::rcmdcheck(
+      sources[[name]],
+      args = c("--no-manual", "--as-cran"),
+      error_on = "never",
+      check_dir = check_dir,
+      timeout = timeout_sec
+    ),
+    error = function(e) e
+  )
+  attr(result, "duration") <- round(as.numeric(Sys.time() - started, units = "secs"))
+  result
+}
+
+pkg_out <- function(name) {
+  dir <- file.path(out_dir, "pkgs", name)
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  dir
+}
+
+# Phase 1: the CRAN version of the package under test is installed; reuse or
+# produce every package's old-version result.
+inform("Phase old: against ", package, " ", our_cran_version)
+for (name in runnable) {
+  entry <- get(name, envir = state)
+  reused <- FALSE
+  if (entry$baseline_planned) {
+    rds <- file.path(baseline_dir, "old-rds", paste0(name, ".rds"))
+    old <- tryCatch(readRDS(rds), error = function(e) NULL)
+    if (!is.null(old)) {
+      saveRDS(old, file.path(pkg_out(name), "old.rds"))
+      donor <- Filter(
+        function(e) identical(e$package, name),
+        read_json(file.path(baseline_dir, "baseline.json"))
+      )
+      update(
+        name,
+        baseline_reused = TRUE,
+        status_old = counts(old),
+        old_checked_at = if (length(donor) > 0) donor[[1]]$checked_at else NA
+      )
+      reused <- TRUE
+      inform(name, ": baseline reused")
+    } else {
+      inform(name, ": planned baseline unavailable, checking fresh")
+    }
+  }
+  if (!reused) {
+    if (out_of_time(entry)) {
+      inform(name, ": deferred (deadline)")
+      next
+    }
+    old <- run_check(name, "old")
+    if (inherits(old, "error")) {
+      update(name, result = "error", message = conditionMessage(old))
+      inform(name, ": old check errored: ", conditionMessage(old))
+      next
+    }
+    saveRDS(old, file.path(pkg_out(name), "old.rds"))
+    update(
+      name,
+      status_old = counts(old),
+      t_old = attr(old, "duration"),
+      old_checked_at = now_utc()
+    )
+    inform(name, ": old ", counts(old), " (", attr(old, "duration"), "s)")
+  }
+}
+
+# Between the phases: the dev binary replaces the CRAN version.
+binary <- file.path(pkg_dir, meta$binary)
+inform("Installing dev binary ", basename(binary))
+if (system2("R", c("CMD", "INSTALL", shQuote(binary))) != 0) {
+  stop("Installing the prebuilt dev binary failed", call. = FALSE)
+}
+our_dev_version <- as.character(utils::packageVersion(package))
+
+# Phase 2: check against the dev version and compare.
+inform("Phase new: against ", package, " ", our_dev_version)
+for (name in runnable) {
+  entry <- get(name, envir = state)
+  if (entry$result != "deferred") {
+    next # depfail or error already decided
+  }
+  if (!file.exists(file.path(pkg_out(name), "old.rds"))) {
+    next # old phase never reached it; stays deferred
+  }
+  if (out_of_time(entry)) {
+    inform(name, ": deferred (deadline)")
+    next
+  }
+  new <- run_check(name, "new")
+  if (inherits(new, "error")) {
+    update(name, result = "error", message = conditionMessage(new))
+    inform(name, ": new check errored: ", conditionMessage(new))
+    next
+  }
+  saveRDS(new, file.path(pkg_out(name), "new.rds"))
+  old <- readRDS(file.path(pkg_out(name), "old.rds"))
+
+  cmp <- tryCatch(
+    rcmdcheck::compare_checks(old, new),
+    error = function(e) NULL
+  )
+  if (is.null(cmp)) {
+    update(name, result = "failed", status_new = counts(new), t_new = attr(new, "duration"))
+  } else {
+    new_issues <- sum(cmp$cmp$change == 1)
+    update(
+      name,
+      result = classify_status(cmp$status, new_issues),
+      status = cmp$status,
+      status_new = counts(new),
+      new_issues = new_issues,
+      t_new = attr(new, "duration")
+    )
+  }
+  entry <- get(name, envir = state)
+  inform(
+    name, ": ", entry$result,
+    " (old ", entry$status_old, ", new ", entry$status_new,
+    ", ", attr(new, "duration"), "s)"
+  )
+
+  # The parsed results carry everything the reports need; raw check output is
+  # kept only where a human will want to dig, and only for the new version.
+  if (entry$result == "ok") {
+    unlink(file.path(work, "check", name), recursive = TRUE)
+  } else {
+    keep <- file.path(out_dir, "pkgs", name, "new-check")
+    dir.create(keep, recursive = TRUE, showWarnings = FALSE)
+    rcheck <- file.path(work, "check", name, "new", paste0(name, ".Rcheck"))
+    for (f in c(
+      "00check.log",
+      "00install.out",
+      list.files(rcheck, pattern = "[.]Rout[.]fail$", recursive = TRUE)
+    )) {
+      if (file.exists(file.path(rcheck, f))) {
+        file.copy(file.path(rcheck, f), file.path(keep, basename(f)))
+      }
+    }
+    unlink(file.path(work, "check", name), recursive = TRUE)
+  }
+}
+
+# ---------------------------------------------------------------- manifest ---
+
+entries <- lapply(members, function(name) get(name, envir = state))
+for (entry in entries) {
+  entry$our_cran_version <- our_cran_version
+  entry$our_dev_version <- our_dev_version
+  cat(
+    jsonlite::toJSON(entry, auto_unbox = TRUE, null = "null"),
+    "\n",
+    sep = "",
+    file = manifest_path,
+    append = TRUE
+  )
+}
+
+# ------------------------------------------------------------------ summary --
+
+results <- vapply(entries, function(e) e$result, character(1))
+df <- data.frame(
+  Package = vapply(entries, function(e) e$package, character(1)),
+  Version = vapply(entries, function(e) e$version, character(1)),
+  Result = results,
+  Old = vapply(entries, function(e) e$status_old, character(1)),
+  New = vapply(entries, function(e) e$status_new, character(1)),
+  Baseline = ifelse(
+    vapply(entries, function(e) isTRUE(e$baseline_reused), logical(1)),
+    "reused",
+    ""
+  )
+)
+append_summary(c(
+  sprintf("### Shard %d", shard_index),
+  "",
+  sprintf(
+    "%d ok, %d newly broken, %d failed, %d depfail, %d error, %d deferred.",
+    sum(results == "ok"), sum(results == "newly_broken"), sum(results == "failed"),
+    sum(results == "depfail"), sum(results == "error"), sum(results == "deferred")
+  ),
+  "",
+  md_table(df)
+))
+for (entry in entries) {
+  if (entry$result %in% c("ok", "deferred")) {
+    next
+  }
+  log <- file.path(out_dir, "pkgs", entry$package, "new-check", "00check.log")
+  lines <- if (nzchar(entry$message)) {
+    strsplit(entry$message, "\n")[[1]]
+  } else if (file.exists(log)) {
+    readLines(log, warn = FALSE)
+  } else {
+    "(no log captured)"
+  }
+  append_summary(md_details(
+    sprintf("<code>%s</code> &mdash; %s", entry$package, entry$result),
+    lines
+  ))
+}
+
+inform(
+  "Shard ", shard_index, " done: ",
+  paste(names(table(results)), table(results), sep = "=", collapse = ", ")
+)

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -1,0 +1,185 @@
+# Shared helpers for the revdep2 workflow scripts.
+# Sourced by plan.R, build.R, shard.R and collect.R; base R plus jsonlite only,
+# so every job can use it before any heavyweight dependency is installed.
+
+# ------------------------------------------------------------- environment --
+
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
+env_chr <- function(name, default = "") {
+  value <- Sys.getenv(name, unset = "")
+  if (identical(value, "")) default else value
+}
+
+env_num <- function(name, default) {
+  value <- suppressWarnings(as.numeric(env_chr(name)))
+  if (length(value) != 1 || is.na(value)) default else value
+}
+
+env_flag <- function(name) {
+  tolower(env_chr(name)) %in% c("1", "true", "yes")
+}
+
+inform <- function(...) {
+  message(paste0(...))
+}
+
+now_utc <- function() {
+  format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+}
+
+# ------------------------------------------------------------------- JSON ----
+
+write_json <- function(x, path) {
+  jsonlite::write_json(x, path, auto_unbox = TRUE, digits = NA, null = "null")
+}
+
+read_json <- function(path, simplify = FALSE) {
+  jsonlite::read_json(path, simplifyVector = simplify)
+}
+
+# --------------------------------------------------------- GitHub plumbing ----
+
+# Append `name=value` to the job's outputs. Values must be single-line.
+set_output <- function(name, value) {
+  path <- Sys.getenv("GITHUB_OUTPUT")
+  if (nzchar(path)) {
+    cat(sprintf("%s=%s\n", name, value), file = path, append = TRUE)
+  } else {
+    inform("[output] ", name, "=", value)
+  }
+}
+
+# Append markdown lines to the job summary, or echo them locally.
+append_summary <- function(lines) {
+  path <- Sys.getenv("GITHUB_STEP_SUMMARY")
+  if (nzchar(path)) {
+    cat(lines, file = path, sep = "\n", append = TRUE)
+    cat("\n", file = path, append = TRUE)
+  } else {
+    cat(lines, sep = "\n")
+    cat("\n")
+  }
+}
+
+# A minimal pipe table so summaries do not need knitr.
+md_table <- function(df) {
+  esc <- function(x) gsub("|", "\\|", as.character(x), fixed = TRUE)
+  header <- paste0("| ", paste(esc(names(df)), collapse = " | "), " |")
+  rule <- paste0("|", paste(rep(" --- ", ncol(df)), collapse = "|"), "|")
+  rows <- vapply(
+    seq_len(nrow(df)),
+    function(i) paste0("| ", paste(esc(unlist(df[i, ])), collapse = " | "), " |"),
+    character(1)
+  )
+  c(header, rule, rows)
+}
+
+# Strip ANSI escapes and carriage returns before quoting logs into markdown.
+sanitize_log <- function(lines) {
+  lines <- gsub("\r", "", lines, fixed = TRUE)
+  gsub("\033\\[[0-9;?]*[a-zA-Z]", "", lines)
+}
+
+# Fence log text so that embedded triple backticks cannot break the summary.
+md_details <- function(title, lines, max_lines = 80) {
+  lines <- sanitize_log(lines)
+  omitted <- character()
+  if (length(lines) > max_lines) {
+    omitted <- sprintf("... (%d earlier lines omitted)", length(lines) - max_lines)
+    lines <- utils::tail(lines, max_lines)
+  }
+  c(
+    sprintf("<details><summary>%s</summary>", title),
+    "",
+    "````text",
+    omitted,
+    lines,
+    "````",
+    "",
+    "</details>",
+    ""
+  )
+}
+
+# ------------------------------------------------------------ CRAN metadata --
+
+cran_repo <- function() {
+  env_chr("REVDEP2_CRAN_MIRROR", "https://cloud.r-project.org")
+}
+
+# available.packages() for the canonical CRAN mirror, fetched once.
+cran_db <- local({
+  db <- NULL
+  function() {
+    if (is.null(db)) {
+      inform("Fetching CRAN package metadata from ", cran_repo())
+      db <<- utils::available.packages(
+        repos = cran_repo(),
+        filters = c("CRAN", "duplicates")
+      )
+    }
+    db
+  }
+})
+
+base_packages <- function() {
+  rownames(utils::installed.packages(priority = c("base", "recommended")))
+}
+
+# The packages that must be installed to check `packages`: their hard
+# dependencies and direct suggests, plus the recursive hard dependencies of
+# all of those. One list per element of `packages`.
+install_closure <- function(packages, db) {
+  direct <- tools::package_dependencies(packages, db = db, which = "most")
+  pool <- unique(unlist(direct, use.names = FALSE))
+  pool <- intersect(pool, rownames(db))
+  recursive <- tools::package_dependencies(
+    pool,
+    db = db,
+    which = "strong",
+    recursive = TRUE
+  )
+  lapply(direct, function(deps) {
+    deps <- intersect(deps, rownames(db))
+    full <- unique(c(deps, unlist(recursive[deps], use.names = FALSE)))
+    sort(setdiff(intersect(full, rownames(db)), base_packages()))
+  })
+}
+
+# Fingerprint of the *versions* of everything a check installs, from CRAN
+# metadata. Two runs whose fingerprints agree resolved the same dependency
+# tree, so an old-version check result can be carried from one to the other.
+dep_fingerprint <- function(deps, db) {
+  if (length(deps) == 0) {
+    return("empty")
+  }
+  lines <- sort(paste(deps, db[deps, "Version"]))
+  path <- tempfile("fingerprint-")
+  on.exit(unlink(path))
+  writeLines(lines, path)
+  unname(tools::md5sum(path))
+}
+
+# ------------------------------------------------------------ result labels --
+
+# Collapse an rcmdcheck comparison (or a failure shim) into the one word the
+# manifest, the collector and the retry selection agree on.
+#   ok           -- no new problems
+#   newly_broken -- the dev version introduces problems the CRAN version lacks
+#   failed       -- the check could not run to a comparable end (install
+#                   failure, timeout, error before/around the check)
+#   depfail      -- dependencies could not be installed, check not attempted
+#   deferred     -- shard deadline hit before this package was checked
+#   error        -- the shard driver itself broke on this package
+classify_status <- function(status, new_issues) {
+  if (status %in% c("+", "-")) {
+    if (identical(status, "-") && new_issues > 0) "newly_broken" else "ok"
+  } else {
+    "failed"
+  }
+}
+
+needs_recheck <- function(result) {
+  !(result %in% c("ok"))
+}


### PR DESCRIPTION
Adds `.github/workflows/revdep2.yaml` plus its script directory `.github/workflows/revdep2/`:
a reverse-dependency check in the spirit of duckdb-r's `each.yaml`,
checking every CRAN revdep against both the CRAN and the dev version of the package
and reporting the difference, revdepcheck-style.
The full design, algorithm rationale, failure-mode table and prior-art survey are in
[`revdep2/README.md`](../blob/claude/revdep2-cynkratemplate-2k0rio/.github/workflows/revdep2/README.md).

## Topology

* **plan** (~1 min) and **build** run in parallel:
  * *plan* enumerates revdeps breadth-first to `depth`
    (1 = direct, 2 = revdeps of revdeps, …, `all` = transitive closure),
    weighs each by CRAN's published check time
    (`tools::CRAN_check_results()`, flavor `r-release-linux-x86_64`),
    resolves which CRAN-baseline results from earlier runs are still valid,
    and emits cost-balanced shards as a matrix.
  * *build* compiles the source tarball and platform binary of the dev version
    (artifact `revdep2-pkg`) — it needs only the checkout,
    so it costs no wall clock of its own; only the shards consume it.
* **preflight** installs and load-tests the *entire* dependency universe,
  so broken dependencies surface before the first check minute is spent,
  and saves the warm pak cache the shards restore (`depfail.json` artifact).
* **test** (one job per shard, `fail-fast: false`, `max-parallel` throttled):
  installs the shard's dependency union (pak, sysreqs on),
  checks each package against the CRAN version (or reuses a baseline),
  swaps in the prebuilt dev binary, checks again, compares.
  Per-check timeout: `max(10 min, 1.5 × the package's CRAN check time)`;
  a killed check is classified as a timeout.
  The shard defers what its deadline cannot fit,
  always attempting at least one check per phase.
* **collect** (`if: always()` past plan/build/preflight):
  merges all shard attempts (and, on a retry, the untouched results of the retried run,
  so the report is always complete),
  writes revdepcheck's own reports (`README.md`, `problems.md`, `failures.md`, `cran.md`)
  through its `results` injection point,
  a machine-readable `manifest.json`,
  and the `revdep2-baseline` artifact future runs reuse.

**Check results never turn the run red** —
the job summary and the `revdep2-report` artifact are the deliverable;
a red job means broken infrastructure, not a broken revdep.

## Key decisions

* **Dispatch-only.** Nothing runs on push.
  The `ref` input checks any branch, tag or commit SHA
  (dispatch itself can only target a branch or tag;
  the tree must contain the revdep2 scripts),
  and `dry-run: true` stops after planning — the free way to inspect a plan.
* **Sharding is greedy** (as agreed):
  the K heaviest packages are dealt round-robin,
  every remaining package (heaviest first) goes where
  `load + weight + install_seconds × |new deps for that shard|` is smallest,
  which pulls dependency-sharing packages together.
  Rationale in the README.
* **Baseline reuse is strict.**
  An old-version result is reused only when the revdep's version,
  our CRAN version, the R series,
  **and the resolved versions of the revdep's whole install closure**
  (md5 fingerprint from CRAN metadata) are unchanged,
  and the result is younger than `baseline-max-age-days` (default 30) —
  the age cap backstops what metadata cannot see.
  Reuse does not refresh the age. `refresh-baseline: true` overrides.
* **Results live in artifacts**
  (`revdep2-report`, `revdep2-baseline`, per-shard results, `revdep2-preflight`),
  with `revdep2/fetch.sh` as the access tooling
  and `retry-run: <run-id>` as the recovery loop.
  Orphan branches remain an option if artifact retention ever bites.
* **Inputs:** `ref`, `packages`, `which` (strong/most), `depth`, `retry-run`,
  `shard-budget-minutes` (default 45), `max-parallel` (default 20),
  `refresh-baseline`, `baseline-max-age-days`, `dry-run`;
  repo-variable fallbacks (`REVDEP2_*`) for the tunables,
  including `REVDEP2_TIMEOUT_FACTOR` / `REVDEP2_TIMEOUT_MIN_MINUTES`.

## Tested locally

* Planner against live CRAN data:
  duckdb (49 revdeps → 6 shards, check estimates within 42–46 min of each other, 7 s),
  dplyr (4,886 revdeps → capped 250 shards, 104–125 min spread, 49 s),
  glasso at `depth: 2` (38 + 54 = 92 packages) and `depth: all`
  (fixpoint at level 3, 106 packages, 8.6 s).
* Full end-to-end micro-run (glasso → revdep `abundant`):
  plan → build → preflight → shard → collect,
  including baseline reuse, the dynamic timeout
  (forced small: killed check classified `failed`/"timed out", run stays green),
  deadline deferral with the first-check exemption,
  a fabricated regression rendered correctly in
  `README.md`/`problems.md`/`cran.md`,
  and retry carry-over of untouched results.

## Remaining known limitations

Bioconductor revdeps are out of scope (CRAN metadata only);
the report generation uses two unexported revdepcheck helpers via `:::`
(manifest-only fallback if they drift);
the cost-model constants are estimates until fitted from real runs
(shard manifests record actual durations for that).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzgPMtgU4T6z6ZoJbo5ZcN