### PR TITLE
ci: Add a Windows arm64 (`windows-11-arm`) check on R-release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -431,7 +431,11 @@ jobs:
       - uses: ./.github/workflows/check
         if: ${{ ! matrix.covr }}
         with:
-          results: ${{ runner.os }}-r${{ matrix.r }}
+          # Include the architecture: the matrix pairs each arm64 runner with an
+          # amd64 one on the same OS and the same R version (ubuntu-26.04-arm /
+          # ubuntu-26.04, windows-11-arm / windows-latest), so `runner.os` alone
+          # yields duplicate artifact names, which upload-artifact rejects.
+          results: ${{ runner.os }}-${{ runner.arch }}-r${{ matrix.r }}
 
       - uses: ./.github/workflows/covr
         if: ${{ matrix.covr }}

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -44,7 +44,30 @@ covr <- data.frame(os = "ubuntu-26.04", r = r_versions[2], covr = "true", desc =
 # since PPM 2026.05.0, so arm64 jobs on @v2 now install binaries, not source.
 linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
 
-include_list <- list(macos, windows, linux_devel, linux, covr, linux_arm64)
+# Windows arm64 (windows-11-arm) is ragged for the same reason as Linux arm64,
+# only more so: a single entry, R-release. Windows on Arm is the youngest of the
+# three arm64 targets, and R for Windows/aarch64 is a separate distribution from
+# the x86_64 one rather than a second build of it, so the point here is to catch
+# "does this package build and check at all on Windows/aarch64", not to sweep R
+# versions. R-release overlaps with the windows-latest (amd64) entries, which
+# keeps the two Windows architectures comparable on at least one R version.
+# Tooling note: r-lib/actions/setup-r resolves the aarch64 Windows installer
+# through the r-hub rversions API and installs the matching aarch64 Rtools45
+# (r-lib/actions NEWS v2.11.4, 2025-10-08). Posit Package Manager publishes no
+# aarch64 Windows binaries, and setup-r's `use-public-rspm: true` enables PPM on
+# x86_64 Windows only, so dependencies are compiled from source on this runner
+# and it is the slowest entry in the matrix.
+windows_arm64 <- data.frame(os = "windows-11-arm", r = r_versions[2])
+
+include_list <- list(
+  macos,
+  windows,
+  linux_devel,
+  linux,
+  covr,
+  linux_arm64,
+  windows_arm64
+)
 
 if (file.exists(".github/versions-matrix.R")) {
   custom <- source(".github/versions-matrix.R")$value


### PR DESCRIPTION
Extends the `rcc-full` version matrix with a Windows on Arm entry,
alongside the Linux arm64 entries added in #88.

## Matrix entry

```r
windows_arm64 <- data.frame(os = "windows-11-arm", r = r_versions[2])
```

Deliberately a single row at R-release,
rather than the `devel` + `release` pair used for Linux arm64.
R for Windows/aarch64 is a *separate distribution* from the x86_64 one,
not a second build of it,
so the question this entry answers is
"does the package build and check at all on Windows/aarch64",
not "how does it behave across R versions on a second architecture".
R-release overlaps with the `windows-latest` rows,
which keeps the two Windows architectures comparable on at least one R version.

The generated matrix gains exactly one job:

```
{"os":"windows-11-arm","r":"4.6"}
```

## Tooling notes (also recorded as comments in `action.R`)

- `r-lib/actions/setup-r` resolves the aarch64 Windows installer through the
  r-hub rversions API
  (`https://api.r-hub.io/rversions/resolve/release/win/arm64`,
  verified to resolve today)
  and installs the matching aarch64 Rtools45 —
  r-lib/actions NEWS `v2.11.4` (2025-10-08).
- Posit Package Manager publishes no aarch64 Windows binaries,
  and `setup-r`'s `use-public-rspm: true` enables PPM on *x86_64* Windows only,
  so dependencies are compiled from source here.
  Expect this to be the slowest entry in the matrix.
- `hendrikmuhs/ccache-action` `v1.2.22` ships `aarch64`/`windows` metadata,
  so the existing ccache setup in `.github/workflows/install` works unchanged.

## Drive-by fix: artifact name collision

`.github/workflows/check` uploads check results under the `results` slug,
which was `${{ runner.os }}-r${{ matrix.r }}`.
The matrix now pairs each arm64 runner with an amd64 one
on the same OS *and* the same R version —
`ubuntu-26.04-arm` / `ubuntu-26.04` (already the case since #88),
and now `windows-11-arm` / `windows-latest` —
so `runner.os` alone yields duplicate artifact names,
which `upload-artifact` rejects.
The slug now includes `runner.arch`.

The upload is gated on `if: failure()`,
so the collision only bites when two same-OS jobs fail together;
it is a latent bug this PR would otherwise make more likely.

## Verification

- Ran `versions-matrix/action.R` locally with the svn version list stubbed
  (`svn.r-project.org` is not reachable from this environment);
  output is valid JSON and contains the new row.
- Parsed `R-CMD-check.yaml` with a YAML loader after the edit.
- Left the file's existing `air` formatting untouched:
  `air format --check` already reported it as unformatted on `main`,
  and there is no `air.toml` in this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PS2uH5wfvj7cLZvRWnFrcY)_