### PR TITLE
ci: Run the full version matrix on pull requests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -431,7 +431,11 @@ jobs:
       - uses: ./.github/workflows/check
         if: ${{ ! matrix.covr }}
         with:
-          results: ${{ runner.os }}-r${{ matrix.r }}
+          # Include the architecture: the matrix pairs each arm64 runner with an
+          # amd64 one on the same OS and the same R version (ubuntu-26.04-arm /
+          # ubuntu-26.04, windows-11-arm / windows-latest), so `runner.os` alone
+          # yields duplicate artifact names, which upload-artifact rejects.
+          results: ${{ runner.os }}-${{ runner.arch }}-r${{ matrix.r }}
 
       - uses: ./.github/workflows/covr
         if: ${{ matrix.covr }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -145,13 +145,21 @@ jobs:
       # did not succeed.
       - id: versions-matrix
         continue-on-error: true
-        # Only run for:
-        # - pull requests if the base repo is different from the head repo
-        # - pull requests if the branch name starts with "cran-"
-        # Do not run for:
-        # - workflow_dispatch if not requested
-        # Always run for other events.
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || startsWith(github.head_ref, 'cran-')) && (github.event_name != 'workflow_dispatch' || inputs.versions-matrix)
+        # Not for workflow_dispatch if not requested, always run for other events.
+        #
+        # Pull requests used to be excluded here unless they came from a fork or
+        # from a "cran-" branch, so the full version matrix only ever ran after
+        # merging. That put every cross-platform regression -- and every change
+        # to the matrix itself -- on the wrong side of the merge button: a job
+        # added to .github/workflows/versions-matrix/action.R could not be
+        # exercised by the pull request that added it. The matrix now runs on
+        # pull requests too, matching the dep-suggests-matrix step below.
+        #
+        # The rcc-full jobs it feeds use fail-fast: false and, on pull_request
+        # events, do not push snapshots back (the update-snapshots action only
+        # opens a pull request when github.event_name != 'pull_request'), so the
+        # widened matrix only adds checks -- it does not add writes.
+        if: github.event_name != 'workflow_dispatch' || inputs.versions-matrix
         uses: ./.github/workflows/versions-matrix
 
       - id: dep-suggests-matrix

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -44,7 +44,30 @@ covr <- data.frame(os = "ubuntu-26.04", r = r_versions[2], covr = "true", desc =
 # since PPM 2026.05.0, so arm64 jobs on @v2 now install binaries, not source.
 linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
 
-include_list <- list(macos, windows, linux_devel, linux, covr, linux_arm64)
+# Windows arm64 (windows-11-arm) is ragged for the same reason as Linux arm64,
+# only more so: a single entry, R-release. Windows on Arm is the youngest of the
+# three arm64 targets, and R for Windows/aarch64 is a separate distribution from
+# the x86_64 one rather than a second build of it, so the point here is to catch
+# "does this package build and check at all on Windows/aarch64", not to sweep R
+# versions. R-release overlaps with the windows-latest (amd64) entries, which
+# keeps the two Windows architectures comparable on at least one R version.
+# Tooling note: r-lib/actions/setup-r resolves the aarch64 Windows installer
+# through the r-hub rversions API and installs the matching aarch64 Rtools45
+# (r-lib/actions NEWS v2.11.4, 2025-10-08). Posit Package Manager publishes no
+# aarch64 Windows binaries, and setup-r's `use-public-rspm: true` enables PPM on
+# x86_64 Windows only, so dependencies are compiled from source on this runner
+# and it is the slowest entry in the matrix.
+windows_arm64 <- data.frame(os = "windows-11-arm", r = r_versions[2])
+
+include_list <- list(
+  macos,
+  windows,
+  linux_devel,
+  linux,
+  covr,
+  linux_arm64,
+  windows_arm64
+)
 
 if (file.exists(".github/versions-matrix.R")) {
   custom <- source(".github/versions-matrix.R")$value


### PR DESCRIPTION
Builds on #99. Against `main` as requested, so the diff currently carries
#99's commit as its first commit — that commit drops out of this PR once #99
merges. Draft until then.

## The change

One condition, in the `versions-matrix` step of `rcc-smoke`:

```diff
-if: (github.event_name != 'pull_request'
-     || github.event.pull_request.head.repo.full_name != github.repository
-     || startsWith(github.head_ref, 'cran-'))
-    && (github.event_name != 'workflow_dispatch' || inputs.versions-matrix)
+if: github.event_name != 'workflow_dispatch' || inputs.versions-matrix
```

which is now character-for-character the condition on the `dep-suggests-matrix`
step directly below it.

## Why

Same-repo pull requests were excluded unless the head branch started with
`cran-` — the branch-prefix opt-in introduced in
[igraph/rigraph#2516](https://github.com/igraph/rigraph/pull/2516)
(`bba036f`, "ci: Test all R versions on branches that start with cran-"),
which is where the expression in this repo came from.
In practice that meant `rcc-full` only ever ran after merging.

Two consequences:

- Cross-platform regressions land on the wrong side of the merge button.
- It is self-defeating for changes to the matrix itself.
  #99 adds a `windows-11-arm` entry that the pull request adding it
  cannot exercise — the only way to find out whether the new runner works
  is to merge and watch `main`.

## Blast radius

The widened matrix adds checks, not writes:

- `rcc-full` sets `fail-fast: false`, so one red platform does not mask the rest.
- On `pull_request` events the `update-snapshots` action does not open snapshot
  pull requests: its `check-changed` step is gated on
  `github.event_name != 'pull_request'`, and the `Create pull request` step is
  gated on `check-changed`. It still *runs* the snapshot tests on same-repo PRs,
  as before.
- `pkgdown-deploy` is unchanged (`github.event_name == 'push'` only).
- `rcc-suggests` is unchanged — still schedule/dispatch only.
- The workflow's `concurrency` group has `cancel-in-progress: true`, so
  force-pushing to a PR branch cancels the previous matrix rather than stacking.

## The cost, stated plainly

Every same-repo pull request now spends roughly 15 runners instead of one.
For this template repo that is the point — the CI *is* the product.
For consumer packages that copy this workflow it is a real per-PR bill, and
`Config/gha/filter` in `DESCRIPTION` remains the escape hatch for trimming the
matrix. Say the word if you would rather gate this behind a label or keep an
opt-out knob, and I will swap it in.

## Verification

Parsed the workflow with a YAML loader and asserted the resolved conditions:

```
versions-matrix      -> github.event_name != 'workflow_dispatch' || inputs.versions-matrix
dep-suggests-matrix  -> github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
rcc-full if:            ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
```

`rcc-full`'s own gate is only the non-empty-matrix check, so nothing downstream
re-excludes pull requests. The `cran-*` entry under `on.push.branches` is
untouched and still meaningful.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PS2uH5wfvj7cLZvRWnFrcY)_