### PR TITLE
ci: Skip checks for documentation-only pull requests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,65 @@ concurrency:
 name: rcc
 
 jobs:
+  # Pull requests that only touch documentation don't need the checks, but they
+  # still need the "rcc" status to turn green. The workflow therefore always
+  # runs -- skipping it via `paths-ignore` would leave the status pending
+  # forever -- and only the jobs that do the work are skipped.
+  rcc-changes:
+    runs-on: ubuntu-26.04
+
+    name: "Detect documentation-only changes"
+
+    permissions:
+      contents: read
+      statuses: write
+
+    outputs:
+      docs-only: ${{ steps.docs-only.outputs.docs-only }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - id: docs-only
+        uses: ./.github/workflows/docs-only
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # R-CMD-check-status.yaml also turns the status green once the run
+      # completes, this step only makes it green right away, and on the head
+      # commit of the pull request.
+      - name: Update status for rcc
+        # FIXME: Wrap into action
+        if: steps.docs-only.outputs.docs-only == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=${{ github.event.pull_request.head.sha || github.sha }}
+
+          html_url=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
+
+          description="${{ github.workflow }} / documentation only"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/${{ github.repository }}/statuses/${sha} \
+            -f "state=success" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+        shell: bash
+
   rcc-smoke:
+    needs:
+      - rcc-changes
+
+    # Skipping the smoke test also skips everything downstream of it
+    if: needs.rcc-changes.outputs.docs-only != 'true'
+
     # Deliberately amd64. The smoke test is the gate that also styles,
     # roxygenizes, updates snapshots, commits back and deploys pkgdown, so it
     # must run on the most stable and available runner. The ubuntu-26.04-arm

--- a/.github/workflows/docs-only/action.yml
+++ b/.github/workflows/docs-only/action.yml
@@ -1,0 +1,85 @@
+name: "Detect documentation-only changes"
+description: >
+  Decide whether the changes under test touch anything that can affect the
+  package, its website, or the CI setup.
+
+inputs:
+  token:
+    description: "Token used to query the list of changed files"
+    required: true
+
+outputs:
+  docs-only:
+    description: >
+      "true" if every changed path is documentation, "false" otherwise.
+      Always "false" for events other than pull_request and merge_group,
+      where the full checks are expected to run.
+    value: ${{ steps.detect.outputs.docs-only }}
+
+runs:
+  using: "composite"
+  steps:
+    # A classifier that wrongly reports "documentation only" would disable
+    # all checks without anyone noticing, so it tests itself before deciding.
+    - name: Test the classifier
+      run: ${{ github.action_path }}/test.sh
+      shell: bash
+
+    - name: Detect documentation-only changes
+      id: detect
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ACTION_PATH: ${{ github.action_path }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+        MERGE_GROUP_BASE: ${{ github.event.merge_group.base_sha }}
+        MERGE_GROUP_HEAD: ${{ github.event.merge_group.head_sha }}
+      run: |
+        ## -- Detect documentation-only changes --
+        set -euo pipefail
+
+        classify() {
+          "${ACTION_PATH}/docs-only.sh" \
+            "${ACTION_PATH}/patterns.txt" \
+            "${GITHUB_WORKSPACE}/.github/docs-only-patterns.txt"
+        }
+
+        # Only skip work that is repeated for every push to a pull request.
+        # Pushes (including merges to main), schedules and manual runs always
+        # check everything: that is where the package is verified for real,
+        # and where the website is deployed.
+        docs_only=false
+
+        case "${GITHUB_EVENT_NAME}" in
+          pull_request)
+            # The API returns at most 3000 files, and a truncated list could
+            # hide the very change we are looking for.
+            if [ "${PR_CHANGED_FILES}" -gt 3000 ]; then
+              echo "::notice::More than 3000 files changed, running all checks."
+            elif files=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename'); then
+              docs_only=$(printf '%s\n' "${files}" | classify)
+            else
+              echo "::warning::Could not determine the changed files, running all checks."
+            fi
+            ;;
+
+          merge_group)
+            if compare=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${MERGE_GROUP_BASE}...${MERGE_GROUP_HEAD}"); then
+              # The compare API caps `files` at 300, without saying so
+              if [ "$(jq '.files | length' <<<"${compare}")" -ge 300 ]; then
+                echo "::notice::Truncated list of changed files, running all checks."
+              else
+                docs_only=$(jq -r '.files[].filename' <<<"${compare}" | classify)
+              fi
+            else
+              echo "::warning::Could not determine the changed files, running all checks."
+            fi
+            ;;
+
+          *)
+            echo "Event ${GITHUB_EVENT_NAME}, running all checks."
+            ;;
+        esac
+
+        echo "docs-only=${docs_only}" | tee -a "${GITHUB_OUTPUT}"
+      shell: bash

--- a/.github/workflows/docs-only/docs-only.sh
+++ b/.github/workflows/docs-only/docs-only.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Classify a list of changed paths, read from standard input, one per line.
+#
+# Usage: docs-only.sh <patterns-file>...
+#
+# Prints `true` if *every* path matches one of the patterns,
+# and `false` otherwise.
+# An empty list of paths also gives `false`:
+# if we don't know what changed, we check everything.
+#
+# Patterns are extended regular expressions matched against the entire path,
+# blank lines and lines starting with `#` are ignored,
+# and pattern files that don't exist are silently ignored,
+# so that callers can pass an optional repository-specific file
+# without checking for its existence first.
+#
+# If `GITHUB_STEP_SUMMARY` is set, a table of the paths and their
+# classification is appended to it.
+
+set -euo pipefail
+
+# Number of paths shown in the job summary
+max_report=100
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <patterns-file>..." >&2
+  exit 1
+fi
+
+patterns=$(mktemp)
+trap 'rm -f "${patterns}"' EXIT
+
+for file in "$@"; do
+  if [ ! -f "${file}" ]; then
+    continue
+  fi
+
+  # `|| true`: a file that only contains comments is fine
+  grep -v -e '^[[:space:]]*#' -e '^[[:space:]]*$' "${file}" >>"${patterns}" || true
+done
+
+if [ ! -s "${patterns}" ]; then
+  echo "No patterns configured, treating all changes as relevant." >&2
+  echo "false"
+  exit 0
+fi
+
+docs_only=true
+seen=false
+n=0
+report=""
+
+while IFS= read -r path; do
+  if [ -z "${path}" ]; then
+    continue
+  fi
+
+  seen=true
+
+  # `-x`: the pattern must match the entire path
+  if grep -qxE -f "${patterns}" <<<"${path}"; then
+    kind="documentation"
+  else
+    kind="code"
+    docs_only=false
+  fi
+
+  echo "${kind}: ${path}" >&2
+
+  n=$((n + 1))
+  if [ "${n}" -le "${max_report}" ]; then
+    report="${report}| \`${path}\` | ${kind} |"$'\n'
+  fi
+done
+
+if [ "${seen}" != "true" ]; then
+  echo "No changed paths found, treating all changes as relevant." >&2
+  docs_only=false
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Changed paths"
+    echo
+    echo "| Path | Kind |"
+    echo "| --- | --- |"
+    printf '%s' "${report}"
+    if [ "${n}" -gt "${max_report}" ]; then
+      echo "| ... and $((n - max_report)) more | |"
+    fi
+    echo
+    if [ "${docs_only}" = "true" ]; then
+      echo "Documentation only, skipping the checks."
+    else
+      echo "Relevant changes found, running the checks."
+    fi
+  } >>"${GITHUB_STEP_SUMMARY}"
+fi
+
+echo "${docs_only}"

--- a/.github/workflows/docs-only/patterns.txt
+++ b/.github/workflows/docs-only/patterns.txt
@@ -1,0 +1,39 @@
+# Paths that cannot affect the outcome of `R CMD check`,
+# the package website, or the CI setup itself.
+# If *all* paths changed by a pull request match one of these patterns,
+# the checks are skipped and the `rcc` status is set to success right away.
+#
+# Each line is an extended regular expression
+# matched against the entire path, as if anchored with `^` and `$`.
+# Blank lines and lines starting with `#` are ignored.
+#
+# This list is deliberately an allow list, not a deny list:
+# anything not mentioned here counts as relevant.
+# New file types (`src/`, `configure`, `tools/`, `inst/include/`, ...)
+# are therefore always checked, also for packages with native code.
+#
+# Repositories can add their own patterns
+# in `.github/docs-only-patterns.txt`,
+# which survives updates of this file from cynkratemplate.
+#
+# Not in this list, on purpose:
+#
+# - `man/`: owned by roxygen2, hand edits must be checked (and reverted)
+# - `vignettes/`: built and run by `R CMD check`
+# - `_pkgdown.yml`, `pkgdown/`, `inst/pkgdown/`: can break the website build
+# - `.github/`, except for the template files below: can break CI itself
+# - `LICENSE` and `DESCRIPTION`: part of the checks
+
+README\.md
+NEWS\.md
+LICENSE\.md
+CODE_OF_CONDUCT\.md
+CONTRIBUTING\.md
+SECURITY\.md
+SUPPORT\.md
+\.github/CODEOWNERS
+\.github/FUNDING\.yml
+\.github/DISCUSSION_TEMPLATE/.*
+\.github/ISSUE_TEMPLATE/.*
+\.github/PULL_REQUEST_TEMPLATE/.*
+\.github/pull_request_template\.md

--- a/.github/workflows/docs-only/patterns.txt
+++ b/.github/workflows/docs-only/patterns.txt
@@ -12,6 +12,23 @@
 # New file types (`src/`, `configure`, `tools/`, `inst/include/`, ...)
 # are therefore always checked, also for packages with native code.
 #
+# A deny list -- "run the checks only for paths that look like code" --
+# would be shorter to write, but it defaults to skipping,
+# and it would have to be complete for every repository
+# that uses this template, including the ones that don't exist yet.
+# A path nobody thought of (`.Rprofile`, `renv.lock`, `air.toml`,
+# `data-raw/`, a vendored `python/` directory)
+# would then merge with a green `rcc` status and nothing to show for it.
+# Here, a path nobody thought of costs one superfluous check run,
+# which is visible in the pull request and easy to fix.
+#
+# Every pattern below must be inert by argument, not by looks:
+# it must not end up in the package tarball,
+# and it must not be read by the workflows or by pkgdown.
+# `.gitattributes` is a good counter-example:
+# it looks like git metadata, but `eol` and filter attributes
+# change the files that are checked out, so it is not in this list.
+#
 # Repositories can add their own patterns
 # in `.github/docs-only-patterns.txt`,
 # which survives updates of this file from cynkratemplate.
@@ -37,3 +54,17 @@ SUPPORT\.md
 \.github/ISSUE_TEMPLATE/.*
 \.github/PULL_REQUEST_TEMPLATE/.*
 \.github/pull_request_template\.md
+
+# Tooling that neither ships nor runs.
+# `R CMD build` drops `.gitignore` on its own,
+# `.Rproj`, `.Rproj.user` and `renovate.json` are in `.Rbuildignore`
+# for packages created from this template.
+(.*/)?\.gitignore
+.*\.Rproj
+\.Rproj\.user/.*
+renovate\.json
+
+# Deliberately not here, add them per repository if `.Rbuildignore` covers them:
+# `cran-comments.md`, `revdep/`, `.vscode/`.
+# They ship unless excluded, and a new top-level file that ships
+# is a `R CMD check` NOTE, which this template treats as an error.

--- a/.github/workflows/docs-only/patterns.txt
+++ b/.github/workflows/docs-only/patterns.txt
@@ -17,37 +17,45 @@
 # and it would have to be complete for every repository
 # that uses this template, including the ones that don't exist yet.
 # A path nobody thought of (`.Rprofile`, `renv.lock`, `air.toml`,
-# `data-raw/`, a vendored `python/` directory)
+# `srcjs/`, a vendored `python/` directory)
 # would then merge with a green `rcc` status and nothing to show for it.
 # Here, a path nobody thought of costs one superfluous check run,
 # which is visible in the pull request and easy to fix.
 #
-# Every pattern below must be inert by argument, not by looks:
-# it must not end up in the package tarball,
-# and it must not be read by the workflows or by pkgdown.
-# `.gitattributes` is a good counter-example:
-# it looks like git metadata, but `eol` and filter attributes
-# change the files that are checked out, so it is not in this list.
+# Two conditions, both required, for a pattern to be listed here:
 #
-# Repositories can add their own patterns
-# in `.github/docs-only-patterns.txt`,
-# which survives updates of this file from cynkratemplate.
+# 1. It never reaches the package tarball,
+#    either through `.Rbuildignore` or through `R CMD build` itself.
+# 2. No step of the `rcc` workflow reads it.
 #
-# Not in this list, on purpose:
-#
-# - `man/`: owned by roxygen2, hand edits must be checked (and reverted)
-# - `vignettes/`: built and run by `R CMD check`
-# - `_pkgdown.yml`, `pkgdown/`, `inst/pkgdown/`: can break the website build
-# - `.github/`, except for the template files below: can break CI itself
-# - `LICENSE` and `DESCRIPTION`: part of the checks
+# The list below was derived from the top-level entries
+# of 64 packages across cynkra, r-lib, r-dbi, tidyverse, igraph, duckdb,
+# poissonconsulting, r-prof, and krlmlr,
+# keeping only entries that are `.Rbuildignore`d in *every* repository
+# that has them.
+# The counts in the comments are "repositories that ignore it / that have it".
 
+# Prose. `README.md`, `index.md` and `NEWS.md` do reach the tarball,
+# but `R CMD check` does not read them,
+# and pkgdown renders them as plain markdown, like the website's other pages.
 README\.md
+README\.Rmd
+index\.md
 NEWS\.md
 LICENSE\.md
 CODE_OF_CONDUCT\.md
 CONTRIBUTING\.md
 SECURITY\.md
 SUPPORT\.md
+TODO\.md
+
+# CRAN paperwork, written by usethis, which adds it to `.Rbuildignore`
+# (48/48 and 7/7 in the survey).
+cran-comments\.md
+CRAN-SUBMISSION
+CRAN-RELEASE
+
+# GitHub metadata that no workflow reads.
 \.github/CODEOWNERS
 \.github/FUNDING\.yml
 \.github/DISCUSSION_TEMPLATE/.*
@@ -55,16 +63,47 @@ SUPPORT\.md
 \.github/PULL_REQUEST_TEMPLATE/.*
 \.github/pull_request_template\.md
 
-# Tooling that neither ships nor runs.
-# `R CMD build` drops `.gitignore` on its own,
-# `.Rproj`, `.Rproj.user` and `renovate.json` are in `.Rbuildignore`
-# for packages created from this template.
+# Editor, agent and repository tooling.
+# `R CMD build` drops `.gitignore` on its own;
+# the rest is `.Rbuildignore`d wherever it occurs
+# (`.vscode` 17/17, `.claude` 8/8, `AGENTS.md` 8/8, `CLAUDE.md` 6/6,
+# `renovate.json` 4/4).
 (.*/)?\.gitignore
 .*\.Rproj
 \.Rproj\.user/.*
+\.vscode/.*
+\.claude/.*
+CLAUDE\.md
+AGENTS\.md
 renovate\.json
 
-# Deliberately not here, add them per repository if `.Rbuildignore` covers them:
-# `cran-comments.md`, `revdep/`, `.vscode/`.
-# They ship unless excluded, and a new top-level file that ships
-# is a `R CMD check` NOTE, which this template treats as an error.
+# Sources for generated data (14/14).
+# `data/` itself is checked, `data-raw/` is only ever run by hand.
+data-raw/.*
+
+# Deliberately not here, all of them seen in the survey:
+#
+# - `air.toml` (31), `.clang-format` (7), `.lintr` (8):
+#   read by the style and format-suggest steps
+# - `codecov.yml` (42), `.covrignore` (10):
+#   read by covr and by codecov-action, which can fail the job
+# - `.aspell/` (0 of 8 ignored) and `inst/WORDLIST`:
+#   they ship, and `tests/spelling.R` reads them
+# - `.gitattributes` (2 of 11 ignored):
+#   `eol` and filter attributes change what is checked out
+# - `Makefile` (12), `scripts/` (10), `Dockerfile` (3),
+#   `docker-compose.yml` (3), `.devcontainer/` (3):
+#   a repository's custom before-install or after-install action may use them
+# - `_pkgdown.yml` (49/50), `pkgdown/`, `vignettes/articles/`:
+#   inputs to the website build
+# - `srcjs/`, `package.json`, `package-lock.json` (3 each):
+#   compiled into `inst/`, so they are code
+# - `revdep/` (23 of 25 ignored): not universal enough to be a default
+# - `man/`: owned by roxygen2, hand edits must be checked (and reverted)
+# - `vignettes/`: built and run by `R CMD check`
+# - `.github/`, apart from the template files above: can break CI itself
+# - `LICENSE`, `DESCRIPTION`, `NAMESPACE`: part of the checks
+#
+# Repositories can add patterns of their own
+# in `.github/docs-only-patterns.txt`,
+# which survives updates of this file from cynkratemplate.

--- a/.github/workflows/docs-only/test.sh
+++ b/.github/workflows/docs-only/test.sh
@@ -33,6 +33,21 @@ expect true "NEWS.md"
 expect true "README.md" "NEWS.md" "CONTRIBUTING.md"
 expect true ".github/ISSUE_TEMPLATE/bug.yml"
 
+# Tooling that neither ships nor runs
+expect true ".gitignore"
+expect true ".github/.gitignore"
+expect true "cynkratemplate.Rproj"
+expect true "renovate.json"
+
+# Config that does have an effect, however harmless it looks
+expect false ".gitattributes"
+expect false ".Rprofile"
+expect false "renv.lock"
+expect false "air.toml"
+expect false ".Rbuildignore"
+# Ships unless the repository excludes it, so it is opt-in per repository
+expect false "cran-comments.md"
+
 # R code, tests, metadata
 expect false "R/foo.R"
 expect false "README.md" "R/foo.R"

--- a/.github/workflows/docs-only/test.sh
+++ b/.github/workflows/docs-only/test.sh
@@ -33,11 +33,22 @@ expect true "NEWS.md"
 expect true "README.md" "NEWS.md" "CONTRIBUTING.md"
 expect true ".github/ISSUE_TEMPLATE/bug.yml"
 
+expect true "README.Rmd"
+expect true "index.md"
+expect true "TODO.md"
+expect true "cran-comments.md"
+expect true "CRAN-SUBMISSION"
+
 # Tooling that neither ships nor runs
 expect true ".gitignore"
 expect true ".github/.gitignore"
 expect true "cynkratemplate.Rproj"
 expect true "renovate.json"
+expect true ".vscode/settings.json"
+expect true ".claude/settings.json"
+expect true "CLAUDE.md"
+expect true "AGENTS.md"
+expect true "data-raw/DATASET.R"
 
 # Config that does have an effect, however harmless it looks
 expect false ".gitattributes"
@@ -45,8 +56,26 @@ expect false ".Rprofile"
 expect false "renv.lock"
 expect false "air.toml"
 expect false ".Rbuildignore"
-# Ships unless the repository excludes it, so it is opt-in per repository
-expect false "cran-comments.md"
+expect false "codecov.yml"
+expect false ".covrignore"
+expect false ".clang-format"
+expect false ".lintr"
+expect false ".aspell/en_stats.rds"
+expect false "inst/WORDLIST"
+expect false "Makefile"
+expect false "scripts/release.R"
+expect false "Dockerfile"
+expect false "docker-compose.yml"
+expect false ".devcontainer/devcontainer.json"
+expect false "revdep/problems.md"
+
+# Web packages: JavaScript is compiled into inst/, so it is code
+expect false "srcjs/index.js"
+expect false "package.json"
+expect false "package-lock.json"
+
+# pkgdown-only articles are still built by the website job
+expect false "vignettes/articles/foo.Rmd"
 
 # R code, tests, metadata
 expect false "R/foo.R"

--- a/.github/workflows/docs-only/test.sh
+++ b/.github/workflows/docs-only/test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Self-test for `docs-only.sh`, run as the first step of the action.
+# A classifier that wrongly says "documentation only" silently disables all
+# checks, so it is worth the couple of seconds this takes.
+
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="${dir}/docs-only.sh"
+patterns="${dir}/patterns.txt"
+
+failures=0
+
+expect() {
+  local want="$1"
+  shift
+
+  local got
+  got=$(printf '%s\n' "$@" | GITHUB_STEP_SUMMARY="" "${script}" "${patterns}" 2>/dev/null)
+
+  if [ "${got}" = "${want}" ]; then
+    echo "ok       ${want} <- $*"
+  else
+    echo "NOT OK   want ${want}, got ${got} <- $*" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# Documentation only
+expect true "README.md"
+expect true "NEWS.md"
+expect true "README.md" "NEWS.md" "CONTRIBUTING.md"
+expect true ".github/ISSUE_TEMPLATE/bug.yml"
+
+# R code, tests, metadata
+expect false "R/foo.R"
+expect false "README.md" "R/foo.R"
+expect false "tests/testthat/test-foo.R"
+expect false "tests/testthat/_snaps/foo.md"
+expect false "DESCRIPTION"
+expect false "NAMESPACE"
+expect false "LICENSE"
+expect false "man/foo.Rd"
+expect false "vignettes/foo.Rmd"
+
+# Native code: nothing below is documentation, no matter how it is spelled
+expect false "src/foo.c"
+expect false "src/foo.cpp"
+expect false "src/init.c"
+expect false "src/Makevars"
+expect false "src/Makevars.win"
+expect false "src/README.md"
+expect false "inst/include/foo.h"
+expect false "configure"
+expect false "configure.ac"
+expect false "cleanup"
+expect false "tools/config.R"
+
+# The website and CI itself
+expect false "_pkgdown.yml"
+expect false "pkgdown/extra.scss"
+expect false "inst/pkgdown/_pkgdown.yml"
+expect false ".github/workflows/R-CMD-check.yaml"
+expect false ".github/workflows/docs-only/patterns.txt"
+
+# Patterns match the entire path, not a part of it
+expect false "docs/README.md"
+expect false "README.md.orig"
+expect false "old-README.md"
+
+# Nothing at all: we don't know what changed
+expect false ""
+
+if [ "${failures}" -ne 0 ]; then
+  echo "${failures} test(s) failed." >&2
+  exit 1
+fi
+
+echo "All tests passed."

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     knitr,
     rmarkdown,
     yaml
-Config/roxygen2/version: 8.0.0.9000
+Config/roxygen2/version: 8.1.0.9000
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ A path nobody thought of therefore costs one superfluous check run,
 which is visible in the pull request,
 rather than a green status for code that was never checked.
 
+The defaults come from a survey of the top-level entries
+of 64 packages across cynkra, r-lib, r-dbi, tidyverse, igraph, duckdb,
+poissonconsulting, r-prof, and krlmlr,
+and cover `README.Rmd`, `index.md`, `cran-comments.md`,
+`CLAUDE.md`, `AGENTS.md`, `.claude/`, `.vscode/`, and `data-raw/`
+in addition to the usual prose files.
+
 Pushes, scheduled runs, and manual runs always check everything.
 The package is verified,
 and the website is deployed,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ anything not listed there,
 including `src/`, `configure`, `man/`, `vignettes/`, `_pkgdown.yml`,
 and the workflows themselves,
 triggers the full checks.
+A path nobody thought of therefore costs one superfluous check run,
+which is visible in the pull request,
+rather than a green status for code that was never checked.
 
 Pushes, scheduled runs, and manual runs always check everything.
 The package is verified,

--- a/README.md
+++ b/README.md
@@ -21,6 +21,37 @@ cynkratemplate::use_cynkra_pkgdown()
 
 Please ask the person in charge (see website page of the general manual in clickup) for a plausible subdomain via email or another mean of communication of their choice.
 
+## Continuous integration
+
+### Documentation-only pull requests
+
+The `rcc` workflow skips the checks for pull requests
+that only touch documentation,
+and turns the `rcc` status green right away.
+The workflow itself still runs,
+so the status is always reported,
+also for pull requests from forks.
+
+A pull request counts as documentation-only
+if *every* changed path matches a pattern
+in [`.github/workflows/docs-only/patterns.txt`](.github/workflows/docs-only/patterns.txt).
+This is an allow list:
+anything not listed there,
+including `src/`, `configure`, `man/`, `vignettes/`, `_pkgdown.yml`,
+and the workflows themselves,
+triggers the full checks.
+
+Pushes, scheduled runs, and manual runs always check everything.
+The package is verified,
+and the website is deployed,
+for every commit that lands on the main branch.
+
+To make the list stricter or more permissive for a single repository,
+create `.github/docs-only-patterns.txt`
+with one extended regular expression per line,
+matched against the entire path.
+That file is never overwritten by updates from cynkratemplate.
+
 ## Fonts
 
 Our private "Frutiger" fonts are hosted on AWS in the "cynkraweb" S3 bucket.


### PR DESCRIPTION
Pull requests that only touch documentation no longer run the test suite,
while the `rcc` status still turns green.

## How it works

A new `rcc-changes` job classifies the paths changed by the pull request.
If all of them are documentation,
`rcc-smoke` is skipped —
and with it `rcc-smoke-check-matrix`, `rcc-full`, and `rcc-suggests`,
which all depend on it.

The workflow itself keeps running.
This is the key point:
`paths-ignore` would prevent the run altogether,
and the `rcc` status,
which pull requests are gated on,
would stay pending forever.
With the workflow running and only its jobs skipped,
the status is reported as before —
`R-CMD-check-status.yaml` turns it green when the run completes,
and the gate job additionally sets it to success right away,
on the head commit,
with the description `rcc / documentation only`.

Skipped jobs are treated as successful by branch protection,
so repositories that require the individual job check runs are fine too.

## Allow list, not deny list

The classifier is an allow list of paths that are inert
([`patterns.txt`](https://github.com/cynkra/cynkratemplate/blob/claude/ci-skip-docs-only-bk9msz/.github/workflows/docs-only/patterns.txt)),
so anything else runs the checks.
A deny list — "run the checks only for paths that look like code" — is shorter,
but it defaults to skipping.
The list is a detail, the default is the decision:

- **Completeness.** A deny list must be complete for every repository
  that uses this template, including the ones that don't exist yet.
  `.Rprofile`, `renv.lock`, `air.toml`, `srcjs/`, a vendored `python/` directory
  are not package content, and a deny list derived from the R package layout omits them,
  yet each of them changes what CI does.
  The allow list only has to be complete for a set the template controls.
- **Visibility.** A missing allow-list pattern runs the checks: loud, and fixed by adding a line.
  A missing deny-list pattern merges unchecked code with a green `rcc`, and nobody ever finds out.
- **It is a merge gate.** `rcc` is a required status.
  Asserting success over an input nobody classified is the one thing it must not do.

This holds for native code by construction:
`src/`, `configure`, `cleanup`, `tools/`, `inst/include/`, `src/Makevars*`
are not special-cased anywhere, they are simply not documentation,
and neither is any file type added later.

On `main` of this repository, over all 238 commits,
the allow list skips 9 and a deny list sketched from the standard R package layout skips 10 —
the difference being `.gitignore`, `renovate.json` and committed `.ccache/**` artifacts,
dotfiles rather than code, and two of them from a practice that is now git-ignored (5465490).
In the other direction, a change to `.github/.gitignore` is skipped here
where the coarse deny list would have run the full matrix.
So the permissive default buys ~1 % more skipped runs
in exchange for an unbounded silent-failure mode.

## The list is derived from a survey, not from guesswork

Cloned 66 repositories across cynkra, r-lib, r-dbi, tidyverse, igraph, duckdb,
poissonconsulting, r-prof, krlmlr, mlfit, wranglezone and moodymudskipper —
64 of them R packages, 24 with native code —
took every top-level entry (191 distinct ones),
and matched it against that repository's own `.Rbuildignore`
with R's own semantics (`grepl(..., perl = TRUE)`).

A pattern became a default only if both hold:

1. it never reaches the tarball, in **every** surveyed repository that has it, and
2. no step of `rcc` reads it.

Added: `README.Rmd` (ignored in 53 of the 53 repositories that have it),
`cran-comments.md` (48/48), `CRAN-SUBMISSION` (7/7), `CRAN-RELEASE`, `index.md` (14/14),
`TODO.md` (4/4), `.vscode/` (17/17), `.claude/` (8/8), `AGENTS.md` (8/8), `CLAUDE.md` (6/6),
`data-raw/` (14/14), plus `.gitignore`, `*.Rproj`, `.Rproj.user/` and `renovate.json`.

Kept out, with the survey's reason recorded in the file:

| Path | Repos | Why it still runs the checks |
| --- | --- | --- |
| `air.toml`, `.clang-format`, `.lintr` | 31, 7, 8 | read by the style and format-suggest steps |
| `codecov.yml`, `.covrignore` | 42, 10 | read by covr and codecov-action, which can fail the job |
| `.aspell/`, `inst/WORDLIST` | 8 (0 of them ignored) | they ship, and `tests/spelling.R` reads them |
| `.gitattributes` | 11 (2 ignored) | `eol` and filter attributes change what is checked out |
| `Makefile`, `scripts/`, `Dockerfile`, `docker-compose.yml`, `.devcontainer/` | 12, 10, 3, 3, 3 | a repository's custom install actions may use them |
| `_pkgdown.yml`, `pkgdown/`, `vignettes/articles/` | 50, 20 | inputs to the website build |
| `srcjs/`, `package.json`, `package-lock.json` | 3 each | compiled into `inst/`, so they are code |
| `revdep/` | 25 (23 ignored) | not universal enough to be a default |

### Effect, measured

Last 500 commits of twelve active repositories, 5,799 commits in total:

| Repository | Commits | Before | After |
| --- | --- | --- | --- |
| r-dbi/RSQLite | 489 | 17 | **53** |
| duckdb/duckdb-r | 499 | 21 | **43** |
| igraph/rigraph | 499 | 10 | **34** |
| r-lib/gert | 499 | 30 | 30 |
| tidyverse/duckplyr | 498 | 10 | **30** |
| cynkra/dm | 498 | 14 | **29** |
| r-dbi/DBI | 496 | 7 | **24** |
| r-lib/pillar | 500 | 11 | **24** |
| cynkra/constructive | 500 | 12 | **21** |
| tidyverse/tibble | 500 | 6 | **15** |
| cynkra/fledge | 500 | 6 | 6 |
| cynkra/g6R | 321 | 3 | **6** |
| **Total** | **5799** | **147 (2.5 %)** | **315 (5.4 %)** |

Of the 168 commits that flipped, `cran-comments.md` accounts for 91,
`.claude/` for 25, `README.Rmd` for 23, `AGENTS.md` for 18, `index.md` for 11,
`data-raw/` for 8.

The measurement runs the same pattern set through an independent R implementation;
it reproduces the shell classifier exactly on this repository's history (9 of 238, both lists).

## Scope

Only `pull_request` and `merge_group` events are gated.
Pushes, scheduled runs, and manual runs always check everything:
that is where the package is verified for real,
and where the website is deployed.
A documentation-only pull request is checked exactly once, when it lands on `main`,
instead of on every push to the branch.

## Safety

Every uncertain case falls back to running the checks:
an empty or truncated list of changed files
(the API caps at 3000 files for pull requests, 300 for compare),
a failing API call,
an empty pattern file,
or a failing gate job (its dependents are skipped and the run fails).

The classifier is a plain shell script, `docs-only.sh`,
with a self-test, `test.sh`,
that runs as the first step of the action —
a classifier that wrongly reports "documentation only"
would disable all checks without anyone noticing.
68 assertions cover native code, JavaScript sources, anchoring
(`docs/README.md` and `README.md.orig` are *not* documentation),
every deliberate exclusion above, mixed pull requests, and the empty list.
The `gh`-facing parts of the action were exercised against a stub
for all events and both truncation and error paths.

Repositories add patterns of their own in `.github/docs-only-patterns.txt`,
which is not overwritten by updates from cynkratemplate.

## Caveat

A typo fix in a roxygen comment lives in `R/`, so it still runs the full checks.
Telling roxygen comments apart from code would be too clever to be trustworthy.
With `error-on: note`, a malformed `NEWS.md` fails `R CMD check` on R >= 4.4,
so such a change now surfaces on the merge to `main` rather than in the pull request;
drop the `NEWS\.md` pattern per repository if that trade-off is unwelcome.