### PR TITLE
ci: Pass workflow context through the environment, not into script text

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -44,11 +44,14 @@ jobs:
           sudo npm install -g json2yaml
 
       - name: Check matrix definition
+        # Passed through the environment rather than spliced into the script:
+        # the matrix is generated from DESCRIPTION in the checkout.
+        env:
+          MATRIX: ${{ needs.matrix.outputs.matrix }}
         run: |
-          matrix='${{ needs.matrix.outputs.matrix }}'
-          echo $matrix
-          echo $matrix | jq .
-          echo $matrix | json2yaml
+          printf '%s\n' "${MATRIX}"
+          printf '%s' "${MATRIX}" | jq .
+          printf '%s' "${MATRIX}" | json2yaml
 
   R-CMD-check-base:
     runs-on: ubuntu-26.04

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -85,32 +85,37 @@ jobs:
       - name: Update status for rcc
         if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # FIXME: Wrap into action
+        # `inputs.ref` is free-form text supplied by whoever dispatched the run
+        # and `github.workflow` comes from the workflow file of the ref under
+        # test, so both are passed through the environment rather than spliced
+        # into the script with `${{ }}`.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
         run: |
+          set -euo pipefail
           echo "Actor: ${{ github.actor }}"
 
           # Check status of this workflow
           state="pending"
-          sha=${{ inputs.ref }}
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-          sha=$(git rev-parse ${sha})
+          sha="${INPUT_REF:-${EVENT_SHA}}"
+          sha=$(git rev-parse "${sha}")
 
           html_url=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
+            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
 
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+            "repos/${REPO}/statuses/${sha}" \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
         shell: bash
 
       - uses: ./.github/workflows/rate-limit
@@ -271,36 +276,36 @@ jobs:
         if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
         run: |
+          set -euo pipefail
           # Check status of this workflow
-          if [ "${{ job.status }}" == "success" ]; then
+          if [ "${JOB_STATUS}" = "success" ]; then
             state="success"
           else
             state="failure"
           fi
 
-          sha=${{ steps.commit.outputs.sha }}
-          if [ -z "${sha}" ]; then
-            sha=${{ inputs.ref }}
-          fi
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-            sha=$(git rev-parse ${sha})
+          sha="${COMMIT_SHA:-${INPUT_REF:-${EVENT_SHA}}}"
+          sha=$(git rev-parse "${sha}")
 
           html_url=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
+            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
 
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+            "repos/${REPO}/statuses/${sha}" \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
         shell: bash
 
       - name: Update status for rcc (Copilot)
@@ -308,32 +313,35 @@ jobs:
         if: always() && (github.actor == 'Copilot')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_STATUS: ${{ job.status }}
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
         run: |
+          set -euo pipefail
           # Set status to success if job succeeded, failure otherwise
-          if [ "${{ job.status }}" == "success" ]; then
+          if [ "${JOB_STATUS}" = "success" ]; then
             state="success"
           else
             state="failure"
           fi
-          sha=${{ inputs.ref }}
-          if [ -z "${sha}" ]; then
-            sha=${{ github.sha }}
-          fi
-          sha=$(git rev-parse ${sha})
+
+          sha="${INPUT_REF:-${EVENT_SHA}}"
+          sha=$(git rev-parse "${sha}")
 
           html_url=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .html_url)
-
-          description="${{ github.workflow }} / ${{ github.job }}"
+            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
 
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            repos/${{ github.repository }}/statuses/${sha} \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${description}" -f "context=rcc"
+            "repos/${REPO}/statuses/${sha}" \
+            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
         shell: bash
 
   rcc-smoke-check-matrix:

--- a/.github/workflows/matrix-check/action.yml
+++ b/.github/workflows/matrix-check/action.yml
@@ -12,11 +12,15 @@ runs:
         sudo npm install -g json2yaml
       shell: bash
 
-    - run: |
-        matrix='${{ inputs.matrix }}'
-        if [ -n "${matrix}" ]; then
-          echo $matrix | jq .
-          echo $matrix | json2yaml
+    # The matrix is generated from repository content, so it is passed through
+    # the environment: a `${{ }}` splice into the single-quoted assignment below
+    # would let a single `'` in the generated JSON escape into the shell.
+    - env:
+        MATRIX: ${{ inputs.matrix }}
+      run: |
+        if [ -n "${MATRIX}" ]; then
+          printf '%s' "${MATRIX}" | jq .
+          printf '%s' "${MATRIX}" | json2yaml
         else
           echo "No matrix found"
         fi

--- a/.github/workflows/rate-limit/action.yml
+++ b/.github/workflows/rate-limit/action.yml
@@ -8,6 +8,11 @@ runs:
   using: "composite"
   steps:
     - name: Check rate limits
+      # The token travels through the environment rather than the command line:
+      # a `${{ }}` splice would embed it in the script text, where `set -x` or a
+      # shell trace in a neighbouring step could surface it.
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: |
-        curl -s --header "authorization: Bearer ${{ inputs.token }}" https://api.github.com/rate_limit
+        curl -s --header "authorization: Bearer ${GH_TOKEN}" https://api.github.com/rate_limit
       shell: bash

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -25,8 +25,10 @@ jobs:
 
     steps:
       - name: Check rate limits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
+          curl -s --header "authorization: Bearer ${GH_TOKEN}" https://api.github.com/rate_limit
         shell: bash
 
       - uses: actions/checkout@v6
@@ -67,11 +69,14 @@ jobs:
           sudo npm install -g json2yaml
 
       - name: Check matrix definition
+        # Passed through the environment rather than spliced into the script:
+        # the matrix is generated from DESCRIPTION in the checkout.
+        env:
+          MATRIX: ${{ needs.matrix.outputs.matrix }}
         run: |
-          matrix='${{ needs.matrix.outputs.matrix }}'
-          echo $matrix
-          echo $matrix | jq .
-          echo $matrix | json2yaml
+          printf '%s\n' "${MATRIX}"
+          printf '%s' "${MATRIX}" | jq .
+          printf '%s' "${MATRIX}" | json2yaml
 
   R-CMD-check:
     needs: matrix
@@ -98,8 +103,10 @@ jobs:
 
     steps:
       - name: Check rate limits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
+          curl -s --header "authorization: Bearer ${GH_TOKEN}" https://api.github.com/rate_limit
         shell: bash
 
       - uses: actions/checkout@v6
@@ -224,6 +231,8 @@ jobs:
 
       - name: Check rate limits
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -s --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit
+          curl -s --header "authorization: Bearer ${GH_TOKEN}" https://api.github.com/rate_limit
         shell: bash

--- a/.github/workflows/update-snapshots/action.yml
+++ b/.github/workflows/update-snapshots/action.yml
@@ -66,11 +66,18 @@ runs:
     - name: Derive branch name
       if: ${{ steps.check-changed.outputs.changed }}
       id: matrix-desc
+      # The matrix is built by .github/workflows/versions-matrix, which reads
+      # DESCRIPTION and sources .github/versions-matrix.R from the checkout, so
+      # its values are repository content. Splicing them into a single-quoted
+      # shell string would let one stray `'` end the quote and run the rest as
+      # commands; the environment keeps them inert.
+      env:
+        MATRIX_JSON: ${{ toJSON(matrix) }}
       run: |
         set -x
-        config=$(echo '${{ toJSON(matrix) }}' | jq -c .)
-        echo "text=$(echo ${config})" | tee -a $GITHUB_OUTPUT
-        echo "branch=$(echo ${config} | sed -r 's/[^0-9a-zA-Z]+/-/g;s/^-//;s/-$//')" | tee -a $GITHUB_OUTPUT
+        config=$(printf '%s' "${MATRIX_JSON}" | jq -c .)
+        echo "text=${config}" | tee -a $GITHUB_OUTPUT
+        echo "branch=$(printf '%s' "${config}" | sed -r 's/[^0-9a-zA-Z]+/-/g;s/^-//;s/-$//')" | tee -a $GITHUB_OUTPUT
       shell: bash
 
     - name: Create pull request


### PR DESCRIPTION
`${{ }}` is textual substitution:
the expression is expanded into the script *before* the shell parses it,
so any quote, backtick or `$(...)` in the value becomes shell syntax.
Values that pass through the environment instead
are read by the shell as data and never re-parsed.

This applies the pattern mechanically,
to the values that are not fixed by GitHub.
No behaviour changes.

## What moved into `env:`

| Value | Where | Why it is not fixed |
| --- | --- | --- |
| `inputs.ref` | the three `rcc` commit-status steps | free-form text supplied by whoever dispatched the run |
| `github.workflow` | same steps | read from the workflow file of the ref under test, not from the default branch |
| `needs.matrix.outputs.matrix` | `check-matrix` in `R-CMD-check-dev` and `revdep` | generated from `DESCRIPTION` in the checkout |
| `inputs.matrix` | `matrix-check` action | same |
| `toJSON(matrix)` | `update-snapshots` action | built from `DESCRIPTION` and `.github/versions-matrix.R` in the checkout |
| `secrets.GITHUB_TOKEN` | `rate-limit` action, `revdep` rate-limit steps | keeps the token off the command line |

The matrix cases are the ones worth a second look:
the JSON writer in `versions-matrix/action.R` escapes `\` and `"` but not `'`,
and every consumer assigned the result inside a single-quoted string
(`matrix='${{ ... }}'`), which is exactly the quote that would end it.

## Incidental

The status steps gain `set -euo pipefail`
and lose their chain of `if [ -z "${sha}" ]` fallbacks
in favour of `${A:-${B:-$C}}`,
which drops one stray-indentation bug along the way:

```diff
-  if [ -z "${sha}" ]; then
-    sha=${{ github.sha }}
-  fi
-    sha=$(git rev-parse ${sha})
```

## Checks

`actionlint` (with `shellcheck`) reports no new findings.
On the files this PR touches the count goes from 6 to 3:
the three `SC2086` warnings about the unquoted `${sha}`
in the status steps are gone.
The remaining three are all in steps this PR does not touch —
`matrix.package` referenced in the non-matrix `R-CMD-check-base` job,
and `SC2016` / `SC2024` in `revdep`.

---

This is the mechanical half of a security review of the workflows.
The rest — authorization gates, `permissions` blocks, action pinning,
and the injection fixes that are not purely mechanical —
follows separately once this lands.