### PR TITLE
ci: Give every workflow and job an explicit `permissions` block

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -12,6 +12,10 @@ on:
 
 name: rcc dev
 
+# Read-only by default; the jobs that need more opt back in below.
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-26.04
@@ -58,6 +62,12 @@ jobs:
 
     name: base
 
+    permissions:
+      # Both required by the update-snapshots action, which opens a pull
+      # request with refreshed snapshots.
+      contents: write
+      pull-requests: write
+
     # Begin custom: services
     # End custom: services
 
@@ -103,6 +113,11 @@ jobs:
     runs-on: ubuntu-26.04
 
     name: 'rcc-dev: ${{ matrix.package }}'
+
+    permissions:
+      # Both required by the update-snapshots action.
+      contents: write
+      pull-requests: write
 
     # Begin custom: services
     # End custom: services

--- a/.github/workflows/R-CMD-check-status.yaml
+++ b/.github/workflows/R-CMD-check-status.yaml
@@ -10,6 +10,8 @@ on:
 
 name: rcc-status
 
+permissions: {}
+
 jobs:
   rcc-status:
     runs-on: ubuntu-26.04
@@ -17,6 +19,10 @@ jobs:
     name: "Update commit status"
 
     permissions:
+      # Required to list and download the triggering run's artifacts.
+      # The workflow did not previously request this, so the `rcc-smoke-sha`
+      # lookup below could not have succeeded.
+      actions: read
       contents: read
       statuses: write
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,6 +50,12 @@ concurrency:
 
 name: rcc
 
+# Read-only by default; every job opts back into what it actually needs.
+# Note that for a pull request from a fork GitHub caps the token at read-only
+# regardless of what is requested here.
+permissions:
+  contents: read
+
 jobs:
   rcc-smoke:
     # Deliberately amd64. The smoke test is the gate that also styles,
@@ -352,6 +358,9 @@ jobs:
     needs:
       - rcc-smoke
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -374,6 +383,13 @@ jobs:
     if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
+
+    permissions:
+      # Both required by the update-snapshots action, which opens a pull
+      # request with refreshed snapshots. It is skipped for forks, where the
+      # token is read-only anyway.
+      contents: write
+      pull-requests: write
 
     # Begin custom: services
     # End custom: services
@@ -461,6 +477,9 @@ jobs:
     if: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix != '' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run-rcc-suggests)) }}
 
     name: Without ${{ matrix.package }}
+
+    permissions:
+      contents: read
 
     # Begin custom: services
     # End custom: services

--- a/.github/workflows/commit-suggest.yaml
+++ b/.github/workflows/commit-suggest.yaml
@@ -6,14 +6,26 @@ on:
     types:
       - completed
 
-permissions:
-  contents: write
-  pull-requests: write
+# Deny everything by default; the job opts back into the minimum it needs.
+# This matters more here than in most workflows: `workflow_run` runs from the
+# default branch with a token that can write to this repository, on runs that
+# belong to a pull request from a fork.
+permissions: {}
 
 jobs:
   commit-suggest:
     runs-on: ubuntu-26.04
     if: github.event.workflow_run.event == 'pull_request'
+
+    permissions:
+      # Required by actions/download-artifact to read another run's artifacts.
+      # The workflow did not previously request this, so the download could
+      # only ever have failed -- silently, under `continue-on-error: true`.
+      actions: read
+      # Required to check out the pull request head
+      contents: read
+      # Required to post the suggestion comment
+      pull-requests: write
 
     steps:
       - name: Show event payload

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yaml
 
+permissions: {}
+
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -23,9 +23,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check_news:
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,11 +16,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.sha }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   pkgdown:
     runs-on: ubuntu-26.04
 
     name: "pkgdown"
+
+    permissions:
+      # Required by pkgdown::deploy_to_branch(), which pushes to gh-pages
+      contents: write
 
     # Begin custom: services
     # End custom: services

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -6,6 +6,9 @@ on:
 
 name: revdep
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-26.04


### PR DESCRIPTION
Only `format-suggest`, `lock`, `R-CMD-check-status`
and the `rcc-smoke` and `fledge` jobs declared their permissions.
Everywhere else the `GITHUB_TOKEN` arrived with whatever the repository default happens to be,
which for most repositories is still write access to every scope.

Nothing relied on that breadth,
so the workflows now deny by default
and each job opts back into what it uses.
The diff is `permissions:` keys and comments, nothing else.

## What each job gets

| Workflow / job | Grant | Why |
| --- | --- | --- |
| `rcc` (top level) | `contents: read` | |
| `rcc-full` | `contents: write`, `pull-requests: write` | snapshot PR from `update-snapshots` |
| `rcc-smoke-check-matrix`, `rcc-suggests` | `contents: read` | |
| `rcc dev` (top level) | `contents: read` | |
| `R-CMD-check-base`, `R-CMD-check-dev` | `contents: write`, `pull-requests: write` | snapshot PR from `update-snapshots` |
| `pkgdown` | `contents: write` | `pkgdown::deploy_to_branch()` pushes to `gh-pages` |
| `commit-suggest` | `actions: read`, `contents: read`, `pull-requests: write` | read another run's artifact, check out the head, post the comment |
| `rcc-status` | `actions: read`, `contents: read`, `statuses: write` | read the run's artifacts, set the status |
| `check_news` (fledge) | `contents: read` | |
| `revdep`, `copilot-setup-steps` (top level) | `contents: read` / `{}` | |

## Two missing scopes, fixed along the way

`commit-suggest` downloads an artifact from another run,
and `rcc-status` lists and downloads the `rcc-smoke-sha` artifact.
Both need `actions: read`, which neither requested —
so those steps could not have been working.
In `commit-suggest` the failure was invisible,
because the download step carries `continue-on-error: true`.

## Scope

This does *not* protect against a pull request from a fork:
there GitHub caps the token at read-only whatever the workflow asks for.
What it bounds is everything else —
a scheduled run, a push, a merge-queue run,
and `workflow_run`, which is the interesting one,
since it runs from the default branch
with a writable token
on runs that belong to a fork.

## Checks

All workflows parse; `actionlint` (with `shellcheck`) reports 11 findings on
both `main` and this branch — unchanged, none in the lines touched here.

I walked each job that inherits a top-level block
against what it actually calls,
to confirm nothing loses a scope it was using:
the `matrix` / `check-matrix` jobs only read,
and artifact upload needs no scope at all.

---

This is the second slice of a security review of the workflows,
after #102. The rest — the `workflow_run` injection fixes,
artifact-SHA validation and action pinning — follows once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKGem7LkqA3KC89yXbVXVj)_