### PR TITLE
ci: Wrap the commit status update into an action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -93,39 +93,11 @@ jobs:
 
       - name: Update status for rcc (pending)
         if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        # FIXME: Wrap into action
-        # `inputs.ref` is free-form text supplied by whoever dispatched the run
-        # and `github.workflow` comes from the workflow file of the ref under
-        # test, so both are passed through the environment rather than spliced
-        # into the script with `${{ }}`.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          INPUT_REF: ${{ inputs.ref }}
-          EVENT_SHA: ${{ github.sha }}
-          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
-        run: |
-          set -euo pipefail
-          echo "Actor: ${{ github.actor }}"
-
-          # Check status of this workflow
-          state="pending"
-          sha="${INPUT_REF:-${EVENT_SHA}}"
-          sha=$(git rev-parse "${sha}")
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/statuses/${sha}" \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
-        shell: bash
+        uses: ./.github/workflows/commit-status
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: pending
+          sha: ${{ inputs.ref }}
 
       - name: Report the GitHub API rate limit
         uses: ./.github/workflows/rate-limit
@@ -297,77 +269,22 @@ jobs:
         shell: bash
 
       - name: Update status for rcc (final)
-        # FIXME: Wrap into action
         if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          JOB_STATUS: ${{ job.status }}
-          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
-          INPUT_REF: ${{ inputs.ref }}
-          EVENT_SHA: ${{ github.sha }}
-          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
-        run: |
-          set -euo pipefail
-          # Check status of this workflow
-          if [ "${JOB_STATUS}" = "success" ]; then
-            state="success"
-          else
-            state="failure"
-          fi
-
-          sha="${COMMIT_SHA:-${INPUT_REF:-${EVENT_SHA}}}"
-          sha=$(git rev-parse "${sha}")
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/statuses/${sha}" \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
-        shell: bash
+        uses: ./.github/workflows/commit-status
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: ${{ job.status }}
+          # The commit that the commit-back step created, if there was one
+          sha: ${{ steps.commit.outputs.sha || inputs.ref }}
 
       - name: Update status for rcc (Copilot)
         # Update status directly when triggered by Copilot or bots, since they can't dispatch workflows
         if: always() && (github.actor == 'Copilot')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          JOB_STATUS: ${{ job.status }}
-          INPUT_REF: ${{ inputs.ref }}
-          EVENT_SHA: ${{ github.sha }}
-          DESCRIPTION: ${{ github.workflow }} / ${{ github.job }}
-        run: |
-          set -euo pipefail
-          # Set status to success if job succeeded, failure otherwise
-          if [ "${JOB_STATUS}" = "success" ]; then
-            state="success"
-          else
-            state="failure"
-          fi
-
-          sha="${INPUT_REF:-${EVENT_SHA}}"
-          sha=$(git rev-parse "${sha}")
-
-          html_url=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/actions/runs/${RUN_ID}" | jq -r .html_url)
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/statuses/${sha}" \
-            -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
-        shell: bash
+        uses: ./.github/workflows/commit-status
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: ${{ job.status }}
+          sha: ${{ inputs.ref }}
 
   rcc-smoke-check-matrix:
     runs-on: ubuntu-26.04

--- a/.github/workflows/commit-status/action.yml
+++ b/.github/workflows/commit-status/action.yml
@@ -1,0 +1,93 @@
+name: "Update the commit status"
+description: >
+  Set the commit status that pull requests are gated on.
+  A workflow reports on the commit it runs on,
+  which for a pull request is the merge commit,
+  and for a run that commits back is the commit before that,
+  so the status has to be set explicitly for the commit
+  the pull request actually shows.
+
+inputs:
+  token:
+    description: "Token used to write the commit status"
+    required: true
+  state:
+    description: >
+      One of `pending`, `success`, `failure` or `error`,
+      or a job status, whose `cancelled` counts as a failure.
+      Anything else fails the step:
+      the status is a merge gate,
+      and a typo must not turn into a green one.
+    required: true
+  sha:
+    description: >
+      Commit to attach the status to, as a sha or as a ref.
+      A ref is resolved with `git rev-parse`,
+      which needs the repository in the workspace;
+      a full sha is used as it stands.
+      Empty means the commit the workflow runs on.
+    required: false
+    default: ""
+  context:
+    description: "Status context, the name that pull requests are gated on"
+    required: false
+    default: "rcc"
+  description:
+    description: "Status description, empty means `<workflow> / <job>`"
+    required: false
+    default: ""
+  target-url:
+    description: "Where the status links to, empty means this workflow run"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Set the ${{ inputs.context }} status to ${{ inputs.state }}"
+      # Nothing is spliced into the script with `${{ }}`:
+      # `inputs.sha` is free-form text supplied by whoever dispatched the run,
+      # and `github.workflow` comes from the workflow file of the ref under test.
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        STATE: ${{ inputs.state }}
+        SHA: ${{ inputs.sha }}
+        CONTEXT: ${{ inputs.context }}
+        DESCRIPTION: ${{ inputs.description }}
+        TARGET_URL: ${{ inputs.target-url }}
+        # `github.job` is the job that uses this action, not a step of it
+        DEFAULT_DESCRIPTION: "${{ github.workflow }} / ${{ github.job }}"
+        DEFAULT_TARGET_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      run: |
+        ## -- Update the commit status --
+        set -euo pipefail
+
+        case "${STATE}" in
+          pending | success | failure | error) ;;
+          # The one value of `job.status` that is not a commit status state
+          cancelled) STATE=failure ;;
+          *)
+            echo "::error::Unknown commit status state: '${STATE}'"
+            exit 1
+            ;;
+        esac
+
+        sha="${SHA:-${GITHUB_SHA}}"
+
+        # `workflow_dispatch` takes a branch or a tag, a status needs a commit.
+        # `--end-of-options` because the ref is free-form text,
+        # `^{commit}` because an annotated tag resolves to the tag object.
+        if ! printf '%s' "${sha}" | grep -qE '^[0-9a-f]{40}$'; then
+          sha=$(git rev-parse --verify --end-of-options "${sha}^{commit}")
+        fi
+
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "repos/${GITHUB_REPOSITORY}/statuses/${sha}" \
+          -f "state=${STATE}" \
+          -f "target_url=${TARGET_URL:-${DEFAULT_TARGET_URL}}" \
+          -f "description=${DESCRIPTION:-${DEFAULT_DESCRIPTION}}" \
+          -f "context=${CONTEXT}"
+      shell: bash


### PR DESCRIPTION
Resolves the two `FIXME: Wrap into action` markers in `R-CMD-check.yaml`.

The same 20 lines of `gh api` set the `rcc` commit status in three places:
the pending status at the start of the smoke test,
the final status at the end of it,
and the Copilot variant of that.
All three now call `.github/workflows/commit-status`,
which takes a state and a commit and does the rest.

```yaml
- name: Update status for rcc
  if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
  uses: ./.github/workflows/commit-status
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    state: ${{ job.status }}
    sha: ${{ steps.commit.outputs.sha || inputs.ref }}
```

The sha fallback chains stay at the call sites, where they differ,
as `||` between candidates;
the action falls back to `github.sha` when it ends up with nothing.

## The state is validated

`rcc` is what pull requests are gated on,
so the one thing the action must never do is post a green status by accident.
It accepts `pending`, `success`, `failure` and `error`,
plus `cancelled`, which is the only job status
that is not a commit status state, and which becomes `failure`.
Anything else fails the step rather than being posted.

That is also why the mapping from the job status lives in the action
and the call sites pass it verbatim:
`success` can then only ever come from a job that actually succeeded,
not from a `&&`/`||` ternary that was typed wrong.

## Two changes beyond moving code

**The run URL is assembled, not fetched.**
`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
is exactly what the API returned as `.html_url`,
so this is the same link with one API call fewer per status update,
three per workflow run.

**Refs are resolved more carefully.**
`git rev-parse --verify --end-of-options "${ref}^{commit}"`, and only when
the input is not already a full sha:

- `--end-of-options` because `inputs.ref` is free-form text from whoever
  dispatched the run, and a ref starting with `-` would otherwise be read as
  an option
- `^{commit}` because an annotated tag resolves to the tag object, and the
  statuses API wants a commit

Everything still goes through the environment rather than `${{ }}` splicing,
as on `main` since 4de0ac2.

## `rcc-status` keeps its own copy, deliberately

An earlier revision of this pull request also routed
`R-CMD-check-status.yaml` through the action.
#106 has since rewritten that file into a self-contained security boundary,
with a preamble spelling out why it must not trust the run it reacts to,
and this no longer looks like a good trade:

- a local action is loaded from the workspace,
  so the job would need an `actions/checkout` it does not need today --
  in the one job in this repository that holds `statuses: write`
  and reacts to attacker-influenced runs
- the job would gain a cross-file indirection
  in exchange for about ten lines,
  right where being readable end to end is the point
- `workflow_run` always runs the copy on the default branch,
  so that change could not be exercised before merging it

The duplication that remains is one `gh api` call on the far side of a trust
boundary, which is a reasonable place for it.

## Verified

Before pushing, the action's script was extracted and run against a stub `gh`
in a scratch repository, once per case:

| Input | Result |
| --- | --- |
| `state: pending`, no sha | `state=pending` on `$GITHUB_SHA` |
| `state: success` | `state=success` |
| `state: cancelled` | `state=failure` |
| `state: definitely-not-a-state` | error annotation, exit 1 |
| `sha: main` | resolved to the branch's commit |
| `sha: v1` (annotated tag) | resolved to the commit, not the tag object |
| `sha: <full sha>`, outside a git repository | posted unchanged |
| `sha: no-such-branch` | exit 128 |
| `description`, `target-url` given | overrides used |

CI then caught what the stub could not:
an action manifest evaluates expressions in an input's `description` too,
and this one documented the state input with a `${{ }}` example,
so the action failed to load with `Unrecognized named-value: 'job'`.
Fixed in the same commit.

On the run after that, in `rcc-smoke`,
both status steps pass, the Copilot one is skipped as intended,
and the smoke test is green.
That run also exercised the fallback chain end to end:
the commit-back step had nothing to commit,
so `steps.commit.outputs.sha` and `inputs.ref` were both empty
and the action fell back to `github.sha`.

Rebased onto `main` after #105, #106 and the `revdep2` workflow landed;
the only difference from `main` in `R-CMD-check.yaml` is the three status steps.