### PR TITLE
ci: Pin third-party actions to commits and let Renovate keep them pinned

### DIFF
--- a/.github/workflows/commit-suggest.yaml
+++ b/.github/workflows/commit-suggest.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Post or update comment
         if: steps.check-artifact.outputs.has_diff == 'true'
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           pr-number: ${{ steps.find-pr.outputs.pr_number }}
           file-path: comment.md

--- a/.github/workflows/covr/action.yml
+++ b/.github/workflows/covr/action.yml
@@ -22,7 +22,7 @@ runs:
         }
       shell: Rscript {0}
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         # Fail if token is given
         fail_ci_if_error: ${{ inputs.token != '' }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -157,7 +157,7 @@ runs:
 
     - name: Install ccache
       # https://github.com/hendrikmuhs/ccache-action/issues/437
-      uses: hendrikmuhs/ccache-action@v1.2.22
+      uses: hendrikmuhs/ccache-action@33522472633dbd32578e909b315f5ee43ba878ce # v1.2.22
       with:
         max-size: 10G
         verbose: 1

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -12,7 +12,10 @@ jobs:
   lock:
     runs-on: ubuntu-26.04
     steps:
-      - uses: krlmlr/lock-threads@patch-1
+      # Pinned to a commit, not to `@patch-1`: a branch ref is mutable, so
+      # anything landing on that branch would run here with write access to
+      # issues, pull requests and discussions.
+      - uses: krlmlr/lock-threads@cf0b2ef2052cc3189765bb2e9c24033039bbfab8 # patch-1
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: "365"

--- a/.github/workflows/pkgdown-deploy/action.yml
+++ b/.github/workflows/pkgdown-deploy/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Deploy site
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
       with:
         timeout_minutes: 15
         max_attempts: 10

--- a/.github/workflows/update-snapshots/action.yml
+++ b/.github/workflows/update-snapshots/action.yml
@@ -84,7 +84,7 @@ runs:
       # Fall through if PR, will use reviewdog/action-suggester in the commit action
       if: ${{ steps.check-changed.outputs.changed }}
       id: cpr
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         base: ${{ inputs.base }}
         branch: snapshot-${{ inputs.base }}-${{ github.job }}-${{ steps.matrix-desc.outputs.branch }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,18 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "Publishers we trust not to rewrite a tag. Keeping them on readable major tags is worth more than a digest here, and the preset above would otherwise pin them.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/**",
+        "r-lib/**",
+        "posit-dev/**"
+      ],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
A `uses:` reference to a tag or a branch
is a promise the upstream repository can rewrite at any time,
and the reference runs with whatever the calling job holds.
This pins the third-party actions to a commit,
with the human-readable version recorded beside it.

The diff is `uses:` lines, one comment, and `renovate.json` — nothing else.

## What is pinned

| Action | Was | Now |
| --- | --- | --- |
| `krlmlr/lock-threads` | `@patch-1` | `cf0b2ef` (`patch-1`) |
| `thollander/actions-comment-pull-request` | `@v3` | `24bffb9` (v3.0.1) |
| `peter-evans/create-pull-request` | `@v8` | `5f6978f` (v8.1.1) |
| `nick-fields/retry` | `@v3` | `ce71cc2` (v3.0.2) |
| `codecov/codecov-action` | `@v5` | `0fb7174` (v5.5.5) |
| `hendrikmuhs/ccache-action` | `@v1.2.22` | `3352247` (v1.2.22) |

`krlmlr/lock-threads@patch-1` is the one that mattered:
a **branch** ref, on a personal fork,
in a job holding `issues: write`, `pull-requests: write` and `discussions: write` —
anything landing on that branch would have run with those scopes.

## What is *not* pinned

`actions`, `r-lib` and `posit-dev` stay on their major tags.
Those are the publishers this template trusts,
and a readable `@v2` is worth more there than a digest.

This needs saying in config, not just in a review:
`helpers:pinGitHubActionDigests` pins *everything*,
so the first Renovate run would have quietly undone that decision.
The package rule in `renovate.json` opts the three publishers back out.

```json
{
  "matchManagers": ["github-actions"],
  "matchPackageNames": ["actions/**", "r-lib/**", "posit-dev/**"],
  "pinDigests": false
}
```

Everything else gets pinned on the way in and kept updated,
which is what makes this maintainable rather than a snapshot that rots.

## A note on annotated tags

Where a publisher uses annotated tags,
`refs/tags/vX` names a **tag object**, not a commit,
and the two have different hashes.
Only the commit works in `uses:`.
That bit me here: my first pass at `codecov-action` used the tag-object hash,
because `git ls-remote --refs` strips the peeled `^{}` entries that reveal the difference.
Every SHA was re-resolved from the peeled ref and verified to exist upstream:

```
codecov/codecov-action                   0fb7174895f6  OK
hendrikmuhs/ccache-action                33522472633d  OK
krlmlr/lock-threads                      cf0b2ef2052c  OK
nick-fields/retry                        ce71cc2ab81d  OK
peter-evans/create-pull-request          5f6978faf089  OK
thollander/actions-comment-pull-request  24bffb9b452b  OK
reviewdog/action-suggester               2558ba17e65a  OK (already on main)
step-security/harden-runner              bf7454d06d71  OK (already on main)
```

The two pins already on `main` were correct.

## Checks

All workflows parse.
`renovate.json` validates against the repository-config schema
with `renovate-config-validator`.
`actionlint` (with `shellcheck`) reports 11 findings on both `main` and this branch.

---

Third slice of a security review of the workflows, after #102 and #103.
The remainder — the two `workflow_run` injection fixes and artifact-SHA
validation — follows once this lands.