### PR TITLE
ci: Name every step and restore the log entry `setup-pandoc` swallows

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -34,8 +34,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
 
-      - id: set-matrix
-        name: Collect the dependencies into a matrix
+      - name: Collect the dependencies into a matrix
+        id: set-matrix
         uses: ./.github/workflows/dep-matrix
 
   check-matrix:

--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -27,13 +27,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/workflows/rate-limit
+      - name: Report the GitHub API rate limit
+        uses: ./.github/workflows/rate-limit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: r-lib/actions/setup-r@v2
 
       - id: set-matrix
+        name: Collect the dependencies into a matrix
         uses: ./.github/workflows/dep-matrix
 
   check-matrix:
@@ -74,10 +76,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           cache-version: rcc-dev-base-1
           needs: build, check
@@ -92,13 +96,16 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
-      - uses: ./.github/workflows/update-snapshots
+      - name: Update the testthat snapshots
+        uses: ./.github/workflows/update-snapshots
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-      - uses: ./.github/workflows/check
+      - name: Run R CMD check
+        uses: ./.github/workflows/check
         with:
           results: ${{ matrix.package }}
 
@@ -123,10 +130,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           cache-version: rcc-dev-${{ matrix.package }}-1
           needs: build, check
@@ -151,12 +160,15 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
-      - uses: ./.github/workflows/update-snapshots
+      - name: Update the testthat snapshots
+        uses: ./.github/workflows/update-snapshots
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-      - uses: ./.github/workflows/check
+      - name: Run R CMD check
+        uses: ./.github/workflows/check
         with:
           results: ${{ matrix.package }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Update status for rcc
+      - name: Update status for rcc (pending)
         if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # FIXME: Wrap into action
         # `inputs.ref` is free-form text supplied by whoever dispatched the run
@@ -127,16 +127,20 @@ jobs:
             -f "state=${state}" -f "target_url=${html_url}" -f "description=${DESCRIPTION}" -f "context=rcc"
         shell: bash
 
-      - uses: ./.github/workflows/rate-limit
+      - name: Report the GitHub API rate limit
+        uses: ./.github/workflows/rate-limit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/workflows/git-identity
+      - name: Configure the Git identity
+        uses: ./.github/workflows/git-identity
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: rcc-smoke-2
@@ -144,7 +148,8 @@ jobs:
           # Beware of using dev pkgdown here, has brought in dev dependencies in the past
           extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/pkgdown deps::.
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
       # Must come after the custom after-install workflow
@@ -158,6 +163,7 @@ jobs:
       # The "Summarize checks" step at the end fails the job if any of them
       # did not succeed.
       - id: versions-matrix
+        name: Collect the R versions into a matrix
         continue-on-error: true
         # Only run for:
         # - pull requests if the base repo is different from the head repo
@@ -169,6 +175,7 @@ jobs:
         uses: ./.github/workflows/versions-matrix
 
       - id: dep-suggests-matrix
+        name: Collect the suggested dependencies into a matrix
         continue-on-error: true
         # Not for workflow_dispatch if not requested, always run for other events
         if: github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
@@ -180,6 +187,7 @@ jobs:
 
       # Styling on foreign PRs works through the format-suggest workflow
       - id: style
+        name: Style the R sources
         continue-on-error: true
         uses: ./.github/workflows/style
         if: steps.repo-state.outputs.foreign != 'true' || steps.repo-state.outputs.is_pr != 'true'
@@ -187,12 +195,14 @@ jobs:
       # Snapshot tests can't work in a way similar to format-suggests
       # because it requires running code which is a security risk on pull_request_target workflows
       - id: snapshots
+        name: Update the testthat snapshots
         continue-on-error: true
         uses: ./.github/workflows/update-snapshots
         with:
           base: ${{ inputs.ref || github.head_ref }}
 
       - id: roxygenize
+        name: Roxygenize the documentation
         continue-on-error: true
         uses: ./.github/workflows/roxygenize
 
@@ -202,18 +212,21 @@ jobs:
         shell: bash
 
       - id: commit
+        name: Commit and push the generated changes
         continue-on-error: true
         uses: ./.github/workflows/commit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: check
+        name: Run R CMD check
         continue-on-error: true
         uses: ./.github/workflows/check
         with:
           results: ${{ runner.os }}-smoke-test
 
       - id: pkgdown-build
+        name: Build the pkgdown website
         continue-on-error: true
         uses: ./.github/workflows/pkgdown-build
         if: github.event_name != 'push'
@@ -225,16 +238,19 @@ jobs:
       # Deploying a broken package's website is worse than not deploying at all,
       # hence this is the one step that is still gated on a check.
       - id: pkgdown-deploy
+        name: Build and deploy the pkgdown website
         continue-on-error: true
         uses: ./.github/workflows/pkgdown-deploy
         if: github.event_name == 'push' && steps.check.outcome == 'success'
 
       # Upload sha as artifact
-      - run: |
+      - name: Record the commit SHA reached by the smoke test
+        run: |
           echo -n "${{ steps.commit.outputs.sha }}" > rcc-smoke-sha.txt
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the commit SHA reached by the smoke test
+        uses: actions/upload-artifact@v5
         with:
           name: rcc-smoke-sha
           path: rcc-smoke-sha.txt
@@ -280,7 +296,7 @@ jobs:
           exit "${status}"
         shell: bash
 
-      - name: Update status for rcc
+      - name: Update status for rcc (final)
         # FIXME: Wrap into action
         if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
@@ -369,11 +385,13 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
-      - uses: ./.github/workflows/matrix-check
+      - name: Show the R versions matrix
+        uses: ./.github/workflows/matrix-check
         with:
           matrix: ${{ needs.rcc-smoke.outputs.versions-matrix }}
 
-      - uses: ./.github/workflows/matrix-check
+      - name: Show the suggested dependencies matrix
+        uses: ./.github/workflows/matrix-check
         with:
           matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
 
@@ -418,17 +436,20 @@ jobs:
           printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
         shell: bash
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           r-version: ${{ matrix.r }}
           cache-version: rcc-full-1
           token: ${{ secrets.GITHUB_TOKEN }}
           needs: build, check
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
       - name: Must allow NOTEs if packages are missing, even with _R_CHECK_FORCE_SUGGESTS_
@@ -443,7 +464,8 @@ jobs:
           }
         shell: Rscript {0}
 
-      - uses: ./.github/workflows/update-snapshots
+      - name: Update the testthat snapshots
+        uses: ./.github/workflows/update-snapshots
         # Generic escape hatch: a custom action may set SKIP_UPDATE_SNAPSHOTS
         # to opt out of running the snapshot updater,
         # which runs tests directly via testthat::test_local()
@@ -452,7 +474,8 @@ jobs:
         with:
           base: ${{ github.head_ref }}
 
-      - uses: ./.github/workflows/check
+      - name: Run R CMD check
+        uses: ./.github/workflows/check
         if: ${{ ! matrix.covr }}
         with:
           # Include the architecture: the matrix pairs each arm64 runner with an
@@ -461,7 +484,8 @@ jobs:
           # yields duplicate artifact names, which upload-artifact rejects.
           results: ${{ runner.os }}-${{ runner.arch }}-r${{ matrix.r }}
 
-      - uses: ./.github/workflows/covr
+      - name: Compute and upload the test coverage
+        uses: ./.github/workflows/covr
         if: ${{ matrix.covr }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -488,10 +512,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           cache-version: rcc-dev-${{ matrix.package }}-1
           needs: build, check
@@ -516,7 +542,8 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
       - name: Must allow NOTEs, even with _R_CHECK_FORCE_SUGGESTS_
@@ -532,7 +559,8 @@ jobs:
           print(Sys.getenv('RCMDCHECK_ERROR_ON'))
         shell: Rscript {0}
 
-      - uses: ./.github/workflows/check
+      - name: Run R CMD check
+        uses: ./.github/workflows/check
         with:
           results: ${{ matrix.package }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -162,8 +162,8 @@ jobs:
       # failing check doesn't hide the results of all the checks that follow.
       # The "Summarize checks" step at the end fails the job if any of them
       # did not succeed.
-      - id: versions-matrix
-        name: Collect the R versions into a matrix
+      - name: Collect the R versions into a matrix
+        id: versions-matrix
         continue-on-error: true
         # Only run for:
         # - pull requests if the base repo is different from the head repo
@@ -174,35 +174,35 @@ jobs:
         if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository || startsWith(github.head_ref, 'cran-')) && (github.event_name != 'workflow_dispatch' || inputs.versions-matrix)
         uses: ./.github/workflows/versions-matrix
 
-      - id: dep-suggests-matrix
-        name: Collect the suggested dependencies into a matrix
+      - name: Collect the suggested dependencies into a matrix
+        id: dep-suggests-matrix
         continue-on-error: true
         # Not for workflow_dispatch if not requested, always run for other events
         if: github.event_name != 'workflow_dispatch' || inputs.dep-suggests-matrix
         uses: ./.github/workflows/dep-suggests-matrix
 
-      - id: repo-state
-        name: Determine repository state
+      - name: Determine repository state
+        id: repo-state
         uses: ./.github/workflows/repo-state
 
       # Styling on foreign PRs works through the format-suggest workflow
-      - id: style
-        name: Style the R sources
+      - name: Style the R sources
+        id: style
         continue-on-error: true
         uses: ./.github/workflows/style
         if: steps.repo-state.outputs.foreign != 'true' || steps.repo-state.outputs.is_pr != 'true'
 
       # Snapshot tests can't work in a way similar to format-suggests
       # because it requires running code which is a security risk on pull_request_target workflows
-      - id: snapshots
-        name: Update the testthat snapshots
+      - name: Update the testthat snapshots
+        id: snapshots
         continue-on-error: true
         uses: ./.github/workflows/update-snapshots
         with:
           base: ${{ inputs.ref || github.head_ref }}
 
-      - id: roxygenize
-        name: Roxygenize the documentation
+      - name: Roxygenize the documentation
+        id: roxygenize
         continue-on-error: true
         uses: ./.github/workflows/roxygenize
 
@@ -211,22 +211,22 @@ jobs:
           rm -f .github/dep-suggests-matrix.json .github/versions-matrix.json
         shell: bash
 
-      - id: commit
-        name: Commit and push the generated changes
+      - name: Commit and push the generated changes
+        id: commit
         continue-on-error: true
         uses: ./.github/workflows/commit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: check
-        name: Run R CMD check
+      - name: Run R CMD check
+        id: check
         continue-on-error: true
         uses: ./.github/workflows/check
         with:
           results: ${{ runner.os }}-smoke-test
 
-      - id: pkgdown-build
-        name: Build the pkgdown website
+      - name: Build the pkgdown website
+        id: pkgdown-build
         continue-on-error: true
         uses: ./.github/workflows/pkgdown-build
         if: github.event_name != 'push'
@@ -237,8 +237,8 @@ jobs:
       # Deployment on workflow_dispatch is available via the pkgdown workflow
       # Deploying a broken package's website is worse than not deploying at all,
       # hence this is the one step that is still gated on a check.
-      - id: pkgdown-deploy
-        name: Build and deploy the pkgdown website
+      - name: Build and deploy the pkgdown website
+        id: pkgdown-deploy
         continue-on-error: true
         uses: ./.github/workflows/pkgdown-deploy
         if: github.event_name == 'push' && steps.check.outcome == 'success'

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -29,10 +29,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: copilot
@@ -40,7 +42,8 @@ jobs:
           # Beware of using dev pkgdown here, has brought in dev dependencies in the past
           extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/styler r-lib/pkgdown deps::.
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
       # Must come after the custom after-install workflow

--- a/.github/workflows/dep-matrix/action.yml
+++ b/.github/workflows/dep-matrix/action.yml
@@ -8,6 +8,7 @@ runs:
   using: "composite"
   steps:
     - id: set-matrix
+      name: Collect the dependencies that have a development repository
       run: |
         # Determine package dependencies
         # From remotes

--- a/.github/workflows/dep-matrix/action.yml
+++ b/.github/workflows/dep-matrix/action.yml
@@ -7,8 +7,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: set-matrix
-      name: Collect the dependencies that have a development repository
+    - name: Collect the dependencies that have a development repository
+      id: set-matrix
       run: |
         # Determine package dependencies
         # From remotes

--- a/.github/workflows/dep-suggests-matrix/action.yml
+++ b/.github/workflows/dep-suggests-matrix/action.yml
@@ -7,8 +7,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: set-matrix
-      name: Collect the suggested dependencies
+    - name: Collect the suggested dependencies
+      id: set-matrix
       run: |
         Rscript ./.github/workflows/dep-suggests-matrix/action.R
       shell: bash

--- a/.github/workflows/dep-suggests-matrix/action.yml
+++ b/.github/workflows/dep-suggests-matrix/action.yml
@@ -8,6 +8,7 @@ runs:
   using: "composite"
   steps:
     - id: set-matrix
+      name: Collect the suggested dependencies
       run: |
         Rscript ./.github/workflows/dep-suggests-matrix/action.R
       shell: bash

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -93,14 +93,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: ./.github/workflows/git-identity
+      - name: Configure the Git identity
+        uses: ./.github/workflows/git-identity
 
       - name: Update apt
         run: |
           sudo apt-get update
         shell: bash
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           packages: ${{ github.repository == 'cynkra/fledge' && 'local::.' || 'cynkra/fledge' }}

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -108,8 +108,10 @@ runs:
       # `r-lib/actions/setup-r@v2` was missing entirely and its output was folded
       # into the collapsed setup-pandoc entry. Emitting the missing `::endgroup::`
       # restores the balance. This step is the one that gets swallowed instead,
-      # which is why it does nothing but say so; drop it once the upstream action
-      # closes its own group.
+      # which is why it does nothing but say so.
+      # Fixed upstream by https://github.com/r-lib/actions/pull/1103; drop this
+      # step, and its two copies in `revdep.yaml` and `revdep2.yaml`, once that
+      # is merged and released in the `v2` tag.
       if: runner.os == 'Linux'
       run: |
         echo "::endgroup::"

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -124,8 +124,8 @@ runs:
         http-user-agent: ${{ matrix.config.http-user-agent }}
         use-public-rspm: true
 
-    - id: get-extra
-      name: Read `Config/gha/extra-packages` from DESCRIPTION
+    - name: Read `Config/gha/extra-packages` from DESCRIPTION
+      id: get-extra
       run: |
         set -x
         packages=$( ( grep Config/gha/extra-packages DESCRIPTION || true ) | cut -d " " -f 2-)

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -99,6 +99,22 @@ runs:
 
     - uses: r-lib/actions/setup-pandoc@v2
 
+    - name: Close the log group that setup-pandoc leaves open
+      # `installPandocLinux()` in r-lib/actions/setup-pandoc writes
+      # `::group::Download pandoc` and never writes the matching `::endgroup::`
+      # (setup-pandoc/src/setup-pandoc.ts, the only `::group::` in that action),
+      # so from there on the job log is one nesting level too deep. The log
+      # viewer then swallows the heading of the step that follows: the entry for
+      # `r-lib/actions/setup-r@v2` was missing entirely and its output was folded
+      # into the collapsed setup-pandoc entry. Emitting the missing `::endgroup::`
+      # restores the balance. This step is the one that gets swallowed instead,
+      # which is why it does nothing but say so; drop it once the upstream action
+      # closes its own group.
+      if: runner.os == 'Linux'
+      run: |
+        echo "::endgroup::"
+      shell: bash
+
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ inputs.r-version }}
@@ -107,6 +123,7 @@ runs:
         use-public-rspm: true
 
     - id: get-extra
+      name: Read `Config/gha/extra-packages` from DESCRIPTION
       run: |
         set -x
         packages=$( ( grep Config/gha/extra-packages DESCRIPTION || true ) | cut -d " " -f 2-)

--- a/.github/workflows/matrix-check/action.yml
+++ b/.github/workflows/matrix-check/action.yml
@@ -15,7 +15,8 @@ runs:
     # The matrix is generated from repository content, so it is passed through
     # the environment: a `${{ }}` splice into the single-quoted assignment below
     # would let a single `'` in the generated JSON escape into the shell.
-    - env:
+    - name: Show the matrix as JSON and as YAML
+      env:
         MATRIX: ${{ inputs.matrix }}
       run: |
         if [ -n "${MATRIX}" ]; then

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,28 +31,35 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/workflows/rate-limit
+      - name: Report the GitHub API rate limit
+        uses: ./.github/workflows/rate-limit
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/workflows/git-identity
+      - name: Configure the Git identity
+        uses: ./.github/workflows/git-identity
         if: github.event_name == 'push'
 
-      - uses: ./.github/workflows/custom/before-install
+      - name: Run the repository-specific before-install steps
+        uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: pkgdown-2
           needs: website
           extra-packages: r-lib/pkgdown local::.
 
-      - uses: ./.github/workflows/custom/after-install
+      - name: Run the repository-specific after-install steps
+        uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
 
-      - uses: ./.github/workflows/pkgdown-build
+      - name: Build the pkgdown website
+        uses: ./.github/workflows/pkgdown-build
         if: github.event_name != 'push'
 
-      - uses: ./.github/workflows/pkgdown-deploy
+      - name: Build and deploy the pkgdown website
+        uses: ./.github/workflows/pkgdown-deploy
         if: github.event_name == 'push'

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -37,8 +37,8 @@ jobs:
       # FIXME: Avoid reissuing successful jobs
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-runs
-      - id: set-matrix
-        name: Collect the reverse dependencies
+      - name: Collect the reverse dependencies
+        id: set-matrix
         run: |
           package <- read.dcf("DESCRIPTION")[, "Package"][[1]]
           deps <- tools:::package_dependencies(package, reverse = TRUE, which = c("Depends", "Imports", "LinkingTo", "Suggests"))[[1]]

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -38,6 +38,7 @@ jobs:
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
       # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#workflow-runs
       - id: set-matrix
+        name: Collect the reverse dependencies
         run: |
           package <- read.dcf("DESCRIPTION")[, "Package"][[1]]
           deps <- tools:::package_dependencies(package, reverse = TRUE, which = c("Depends", "Imports", "LinkingTo", "Suggests"))[[1]]
@@ -98,7 +99,7 @@ jobs:
       RGL_USE_NULL: true
 
     steps:
-      - name: Check rate limits
+      - name: Check rate limits before checking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -119,6 +120,13 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Close the log group that setup-pandoc leaves open
+        # See `.github/workflows/install/action.yml` for why this is needed.
+        if: runner.os == 'Linux'
+        run: |
+          echo "::endgroup::"
+        shell: bash
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -219,7 +227,7 @@ jobs:
           name: ${{ matrix.package }}-results
           path: revdep/${{ matrix.package }}
 
-      - name: Check rate limits
+      - name: Check rate limits after checking
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Close the log group that setup-pandoc leaves open
         # See `.github/workflows/install/action.yml` for why this is needed.
+        # Fixed upstream by https://github.com/r-lib/actions/pull/1103.
         if: runner.os == 'Linux'
         run: |
           echo "::endgroup::"

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -328,6 +328,7 @@ jobs:
 
       - name: Close the log group that setup-pandoc leaves open
         # See `.github/workflows/install/action.yml` for why this is needed.
+        # Fixed upstream by https://github.com/r-lib/actions/pull/1103.
         if: runner.os == 'Linux'
         run: |
           echo "::endgroup::"

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -170,7 +170,8 @@ jobs:
           Rscript ./.github/workflows/revdep2/plan.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the shard plan
+        uses: actions/upload-artifact@v5
         if: steps.plan.outputs.shards != '0'
         with:
           name: revdep2-plan
@@ -196,7 +197,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: ./.github/workflows/install
+      - name: Install R and the package dependencies
+        uses: ./.github/workflows/install
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: revdep2-1
@@ -209,7 +211,8 @@ jobs:
           Rscript ./.github/workflows/revdep2/build.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the package source
+        uses: actions/upload-artifact@v5
         with:
           name: revdep2-pkg
           path: ${{ runner.temp }}/pkg
@@ -246,14 +249,16 @@ jobs:
           install.packages("jsonlite")
         shell: Rscript {0}
 
-      - uses: actions/download-artifact@v6
+      - name: Download the shard plan
+        uses: actions/download-artifact@v6
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
       # The preflight downloads every dependency binary once; saving the pak
       # cache under the plan's hash hands the shards a warm start.
-      - uses: actions/cache@v4
+      - name: Cache the pak package cache
+        uses: actions/cache@v4
         with:
           path: ~/.cache/R/pkgcache
           key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
@@ -269,7 +274,8 @@ jobs:
           Rscript ./.github/workflows/revdep2/preflight.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the preflight library
+        uses: actions/upload-artifact@v5
         with:
           name: revdep2-preflight
           path: ${{ runner.temp }}/preflight
@@ -320,6 +326,13 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - name: Close the log group that setup-pandoc leaves open
+        # See `.github/workflows/install/action.yml` for why this is needed.
+        if: runner.os == 'Linux'
+        run: |
+          echo "::endgroup::"
+        shell: bash
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
@@ -338,26 +351,30 @@ jobs:
           install.packages(c("jsonlite", "rcmdcheck"))
         shell: Rscript {0}
 
-      - uses: actions/cache/restore@v4
+      - name: Restore the pak package cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/R/pkgcache
           key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
           restore-keys: |
             revdep2-pak-
 
-      - uses: actions/download-artifact@v6
+      - name: Download the shard plan
+        uses: actions/download-artifact@v6
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
-      - uses: actions/download-artifact@v6
+      - name: Download the package source
+        uses: actions/download-artifact@v6
         with:
           name: revdep2-pkg
           path: ${{ runner.temp }}/pkg
 
       # The baseline lives on an earlier run; absence is not an error, the
       # shard just checks the CRAN version fresh.
-      - uses: actions/download-artifact@v6
+      - name: Download the baseline results
+        uses: actions/download-artifact@v6
         if: needs.plan.outputs.baseline_run != '0'
         continue-on-error: true
         with:
@@ -384,7 +401,8 @@ jobs:
       # Named per attempt: a re-run of one shard must not overwrite the results
       # the other shards uploaded in the first attempt; the collector reads
       # every attempt and lets the later one win per package.
-      - uses: actions/upload-artifact@v5
+      - name: Upload the shard results
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: revdep2-results-${{ matrix.shard }}-${{ github.run_attempt }}
@@ -439,17 +457,20 @@ jobs:
           pak::pkg_install("krlmlr/revdepcheck")
         shell: Rscript {0}
 
-      - uses: actions/download-artifact@v6
+      - name: Download the shard plan
+        uses: actions/download-artifact@v6
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
-      - uses: actions/download-artifact@v6
+      - name: Download the results of all shards
+        uses: actions/download-artifact@v6
         with:
           pattern: revdep2-results-*
           path: ${{ runner.temp }}/results
 
-      - uses: actions/download-artifact@v6
+      - name: Download the report of the run being retried
+        uses: actions/download-artifact@v6
         if: env.REVDEP2_RETRY_RUN != ''
         continue-on-error: true
         with:
@@ -469,7 +490,8 @@ jobs:
           Rscript ./.github/workflows/revdep2/collect.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the report
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: revdep2-report
@@ -477,7 +499,8 @@ jobs:
           retention-days: 90
           overwrite: true
 
-      - uses: actions/upload-artifact@v5
+      - name: Upload the new baseline
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: revdep2-baseline

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -161,8 +161,8 @@ jobs:
           install.packages("jsonlite")
         shell: Rscript {0}
 
-      - id: plan
-        name: Plan shards
+      - name: Plan shards
+        id: plan
         env:
           GH_TOKEN: ${{ github.token }}
           OUT: ${{ runner.temp }}/plan.json

--- a/.github/workflows/versions-matrix/action.yml
+++ b/.github/workflows/versions-matrix/action.yml
@@ -13,8 +13,8 @@ runs:
         sudo npm install -g json2yaml
       shell: bash
 
-    - id: set-matrix
-      name: Collect the R versions to check
+    - name: Collect the R versions to check
+      id: set-matrix
       run: |
         Rscript ./.github/workflows/versions-matrix/action.R
       shell: bash

--- a/.github/workflows/versions-matrix/action.yml
+++ b/.github/workflows/versions-matrix/action.yml
@@ -14,6 +14,7 @@ runs:
       shell: bash
 
     - id: set-matrix
+      name: Collect the R versions to check
       run: |
         Rscript ./.github/workflows/versions-matrix/action.R
       shell: bash


### PR DESCRIPTION
## The missing `setup-r` log entry

In the web log viewer, the `install` action showed no entry for `r-lib/actions/setup-r@v2` at all — the list jumped straight from `Run r-lib/actions/setup-pandoc@v2` to the step after it, and setup-r's ~1350 lines were folded into the collapsed setup-pandoc entry.

The runner does log the step; the raw log contains `##[start-action display=Run r-lib/actions/setup-r@v2;...]` with `outcome=success`. The cause is upstream: `installPandocLinux()` in `r-lib/actions/setup-pandoc` writes `::group::Download pandoc` and never writes the matching `::endgroup::` (setup-pandoc/src/setup-pandoc.ts, the only `::group::` in that action, on the Linux path only). From there on the job log is one nesting level too deep, and the viewer swallows the heading of the step that follows.

This PR emits the missing `::endgroup::` right after setup-pandoc — in the `install` action and in the two workflows that call setup-pandoc directly (`revdep`, `revdep2`). The no-op step is the one that gets swallowed instead, which is why it does nothing but say so.

The upstream fix is r-lib/actions#1103; each of the three copies carries a comment pointing at it, so they can be dropped once it is merged and released in the `v2` tag.

Verified on a dispatched run of `rcc` on this branch. Group depth measured per step, before and after each `start-action`/`end-action` pair:

- before: `setup-pandoc` in=0 out=1, then **every** step to the end of the job at in=1 out=1
- after: `setup-pandoc` in=0 out=1, `Close the log group that setup-pandoc leaves open` in=1 out=0, `setup-r` in=0 out=0, and every remaining step at in=0 out=0

## Step names

`Run set -x` was the unnamed `get-extra` step: with no `name:`, the runner synthesizes a display label from the first line of the `run:` script. Every `run:` step in the repository now has a name — seven lacked one (`get-extra`, the `set-matrix` steps in `dep-matrix`, `dep-suggests-matrix`, `versions-matrix` and `revdep`, the unnamed step in `matrix-check`, and the SHA artifact step in `rcc`).

Steps that invoke a local composite action are named too, so the top-level entries read as what they do rather than as a path — `Install R and the package dependencies` instead of `Run ./.github/workflows/install`. Two names that occurred twice within one job are disambiguated (`Update status for rcc` → `(pending)`/`(final)`, `Check rate limits` → `before checking`/`after checking`).

Third-party `uses:` steps keep their automatic `Run <action>` label, which is self-describing. The exception is `revdep2`, where up to three `actions/download-artifact@v6` steps shared a job and were indistinguishable in the log; those, and the neighbouring upload/cache steps, are named after the artifact they move.

## Consistent step layout

`name` and `uses` are now the only keys that can follow a step's `- `. Seventeen steps opened with `- id:` and carried their `name` on the second line; the two are swapped, so the bullet line always says what the step is and the remaining keys line up underneath.

## On the green checkmarks

For the record, since this came up alongside the above: the green checkmark, the duration on the right, and the label of a nested log entry all come from a marker pair the runner writes around each step of a composite action:

```
##[start-action display=Add pkg.lock to .gitignore;id=__self_2.__run_8]
##[end-action id=__self_2.__run_8;outcome=success;conclusion=success;duration_ms=18]
```

The icon is `conclusion`, the time is `duration_ms`, the label is `display`. The runner emits these automatically and only for composite-action sub-steps; no workflow syntax produces them, and a plain `::group::` yields a collapsible row with neither icon nor duration. Top-level job steps emit no such markers — the UI draws their status from the job's `steps[]` API array with a different icon — so this cannot be extended to entries like `Run ./.github/workflows/install`. That step is already a composite action, so its contents are exactly the green rows; the label was the actionable part, and that is what changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp9mp5oU9GoNvviVicEkNE